### PR TITLE
fix: 関係ないスレッドでのリアクション追加を防止

### DIFF
--- a/src/admin/message-router.ts
+++ b/src/admin/message-router.ts
@@ -48,9 +48,6 @@ export class MessageRouter {
       hasReactionCallback: !!onReaction,
     });
 
-    // メッセージ受信確認のリアクションを追加
-    await this.addMessageReceivedReaction(threadId, onReaction);
-
     // VERBOSEモードでの詳細ログ出力
     this.logMessageDetails(threadId, message);
 
@@ -71,6 +68,9 @@ export class MessageRouter {
       return err(workerResult.error);
     }
     const worker = workerResult.value;
+
+    // Workerが見つかった場合のみメッセージ受信確認のリアクションを追加
+    await this.addMessageReceivedReaction(threadId, onReaction);
 
     // 監査ログに記録
     await this.logAuditEntry(threadId, "message_received", {


### PR DESCRIPTION
MessageRouter でWorker存在確認の前にリアクションが追加されていた問題を修正。
Worker が見つかった場合のみメッセージ受信確認のリアクション（👀）を追加するように変更。

- addMessageReceivedReaction の呼び出しを findWorkerForThread の後に移動
- botが作成していないスレッドではリアクションもメッセージも何も反応しないように修正

🤖 Generated with [Claude Code](https://claude.ai/code)