### PR TITLE
ブランチ名の形式を worker/work-[yyyyMMdd]-[hhmmss]-[workerName] に変更

### DIFF
--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -240,10 +240,21 @@ export async function isWorktreeCopyExists(
 
 /**
  * ブランチ名を生成する
+ * フォーマット: worker/work-[yyyyMMdd]-[hhmmss]-[workerName]
  */
-function generateBranchName(workerName: string): string {
-  const timestamp = Date.now();
-  return `worker-${workerName}-${timestamp}`;
+export function generateBranchName(workerName: string): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  const hours = String(now.getHours()).padStart(2, "0");
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  const seconds = String(now.getSeconds()).padStart(2, "0");
+
+  const dateStr = `${year}${month}${day}`;
+  const timeStr = `${hours}${minutes}${seconds}`;
+
+  return `worker/work-${dateStr}-${timeStr}-${workerName}`;
 }
 
 /**

--- a/test/git-utils.test.ts
+++ b/test/git-utils.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "std/assert/mod.ts";
-import { parseRepository } from "../src/git-utils.ts";
+import { generateBranchName, parseRepository } from "../src/git-utils.ts";
 
 Deno.test("parseRepository関数のテスト", async (t) => {
   await t.step("正常なリポジトリ名をパースできる", () => {
@@ -67,5 +67,86 @@ Deno.test("parseRepository関数のテスト", async (t) => {
         );
       }
     }
+  });
+});
+
+Deno.test("generateBranchName関数のテスト", async (t) => {
+  await t.step("正しいフォーマットのブランチ名を生成する", () => {
+    const workerName = "test-worker";
+    const branchName = generateBranchName(workerName);
+
+    // フォーマットが正しいかチェック
+    const pattern = /^worker\/work-\d{8}-\d{6}-test-worker$/;
+    assertEquals(pattern.test(branchName), true);
+
+    // プレフィックスが正しいかチェック
+    assertEquals(branchName.startsWith("worker/work-"), true);
+
+    // worker名が末尾に含まれているかチェック
+    assertEquals(branchName.endsWith("-test-worker"), true);
+  });
+
+  await t.step("日付と時刻が正しい形式で含まれる", () => {
+    const workerName = "test-worker";
+    const beforeCall = new Date();
+    const branchName = generateBranchName(workerName);
+    const afterCall = new Date();
+
+    // ブランチ名から日付と時刻を抽出
+    const match = branchName.match(
+      /^worker\/work-(\d{8})-(\d{6})-test-worker$/,
+    );
+    assertEquals(match !== null, true);
+
+    if (match) {
+      const [, dateStr, timeStr] = match;
+
+      // 日付フォーマットの確認 (YYYYMMDD)
+      assertEquals(dateStr.length, 8);
+      const year = parseInt(dateStr.substring(0, 4));
+      const month = parseInt(dateStr.substring(4, 6));
+      const day = parseInt(dateStr.substring(6, 8));
+
+      // 時刻フォーマットの確認 (HHMMSS)
+      assertEquals(timeStr.length, 6);
+      const hours = parseInt(timeStr.substring(0, 2));
+      const minutes = parseInt(timeStr.substring(2, 4));
+      const seconds = parseInt(timeStr.substring(4, 6));
+
+      // 値の妥当性チェック
+      assertEquals(year >= beforeCall.getFullYear(), true);
+      assertEquals(year <= afterCall.getFullYear(), true);
+      assertEquals(month >= 1 && month <= 12, true);
+      assertEquals(day >= 1 && day <= 31, true);
+      assertEquals(hours >= 0 && hours <= 23, true);
+      assertEquals(minutes >= 0 && minutes <= 59, true);
+      assertEquals(seconds >= 0 && seconds <= 59, true);
+    }
+  });
+
+  await t.step("異なるworkerNameでも正しく動作する", () => {
+    const workerNames = ["worker1", "my-worker", "worker_123", "test"];
+
+    for (const workerName of workerNames) {
+      const branchName = generateBranchName(workerName);
+
+      // 各workerNameに対して正しいフォーマットかチェック
+      const pattern = new RegExp(`^worker\/work-\\d{8}-\\d{6}-${workerName}$`);
+      assertEquals(pattern.test(branchName), true);
+    }
+  });
+
+  await t.step("連続して呼び出しても異なるブランチ名を生成する", () => {
+    const workerName = "test-worker";
+    const branchName1 = generateBranchName(workerName);
+    // 1秒待機して異なる時刻を確保
+    const start = Date.now();
+    while (Date.now() - start < 1000) {
+      // 1秒待機
+    }
+    const branchName2 = generateBranchName(workerName);
+
+    // 時刻が異なるため、ブランチ名も異なるはず
+    assertEquals(branchName1 !== branchName2, true);
   });
 });


### PR DESCRIPTION
## Summary

- `generateBranchName`関数を新しいフォーマットに更新
- 日付と時刻が人間に読みやすい形式で含まれるようになった
- 従来の `worker-[workerName]-[timestamp]` から `worker/work-[yyyyMMdd]-[hhmmss]-[workerName]` に変更

## Changes

### Before
```
worker-1394616794643169401-1752572957379
```

### After
```
worker/work-20250715-143025-1394616794643169401
```

## Test plan

- [x] `generateBranchName`関数の包括的なテストを追加
- [x] 新しいフォーマットの正確性を確認
- [x] 日付・時刻の形式と値の妥当性をテスト
- [x] 異なるworkerNameでの動作確認
- [x] 型チェック、lint、フォーマットチェック全てパス

🤖 Generated with [Claude Code](https://claude.ai/code)