### PR TITLE
feat: レート制限時にDiscordステータスで復旧予定時刻を表示 + エラー検知強化

### DIFF
--- a/src/admin/admin.ts
+++ b/src/admin/admin.ts
@@ -11,6 +11,7 @@ import { RateLimitManager } from "./rate-limit-manager.ts";
 import { DevcontainerManager } from "./devcontainer-manager.ts";
 import { MessageRouter } from "./message-router.ts";
 import { err, ok, Result } from "neverthrow";
+import type { Client } from "discord.js";
 
 export class Admin implements IAdmin {
   private state: AdminState;
@@ -514,6 +515,13 @@ export class Admin implements IAdmin {
     callback: (threadId: string, message: string) => Promise<void>,
   ): void {
     this.rateLimitManager.setAutoResumeCallback(callback);
+  }
+
+  /**
+   * DiscordクライアントをRateLimitManagerに設定する
+   */
+  setDiscordClient(client: Client): void {
+    this.rateLimitManager.setDiscordClient(client);
   }
 
   /**

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -66,6 +66,7 @@ export interface IAdmin {
   setAutoResumeCallback(
     callback: (threadId: string, message: string) => Promise<void>,
   ): void;
+  setDiscordClient(client: import("discord.js").Client): void;
   setThreadCloseCallback(
     callback: (threadId: string) => Promise<void>,
   ): void;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import {
+  ActivityType,
   AutocompleteInteraction,
   ButtonInteraction,
   ChannelType,
@@ -9,6 +10,7 @@ import {
   Message,
   Partials,
   PermissionFlagsBits,
+  PresenceUpdateStatus,
   REST,
   Routes,
   SlashCommandBuilder,
@@ -198,6 +200,18 @@ const commands = [
 // Bot起動時の処理
 client.once(Events.ClientReady, async (readyClient) => {
   console.log(`ログイン完了: ${readyClient.user.tag}`);
+
+  // 初期プレゼンス設定
+  await readyClient.user.setPresence({
+    activities: [{
+      name: "Claude Code Bot で開発支援中",
+      type: ActivityType.Playing,
+    }],
+    status: PresenceUpdateStatus.Online,
+  });
+
+  // DiscordクライアントをAdminに設定
+  admin.setDiscordClient(readyClient);
 
   // 自動再開コールバックを設定
   admin.setAutoResumeCallback(async (threadId: string, message: string) => {


### PR DESCRIPTION
Claude AI usage limit reached エラー発生時の機能を強化

## 機能追加
- レート制限時にDiscordステータスで復旧予定時刻を表示
- 制限時: 「制限中 - 14:30頃復旧予定」として DoNotDisturb ステータス
- 復旧時: 「Claude Code Bot で開発支援中」として Online ステータス

## バグ修正
- Claude AI usage limit reached エラーの検知を強化
- assistantメッセージ内での検知を追加
- 生テキスト出力での検知を追加
- デバッグログを強化