### PR TITLE
feat: remove ManageThreads permission requirement from stop and plan commands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -191,12 +191,10 @@ const commands = [
   new SlashCommandBuilder()
     .setName("stop")
     .setDescription("実行中のClaude Codeを中断します")
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageThreads)
     .toJSON(),
   new SlashCommandBuilder()
     .setName("plan")
     .setDescription("Claude Codeをプランモードに設定します")
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageThreads)
     .toJSON(),
   new SlashCommandBuilder()
     .setName("close")


### PR DESCRIPTION
## Summary
- /stopと/planコマンドからManageThreads権限制限を削除
- 全てのユーザーが実行中断とプランモード設定を使用可能に

## Test plan
- [x] 型チェック通過
- [x] テスト通過  
- [x] lint通過
- [x] フォーマット通過

🤖 Generated with [Claude Code](https://claude.ai/code)