### PR TITLE
Refactor Codex execution to use exec JSON mode

### DIFF
--- a/src/worker/codex-cli-capabilities.ts
+++ b/src/worker/codex-cli-capabilities.ts
@@ -2,6 +2,15 @@ const decoder = new TextDecoder();
 
 let cachedHelpText: string | null = null;
 let helpDetectionAttempted = false;
+
+let cachedExecHelpText: string | null = null;
+let execHelpDetectionAttempted = false;
+
+let cachedExecJsonSupport: boolean | null = null;
+let cachedExecColorSupport: boolean | null = null;
+let cachedExecResumeSupport: boolean | null = null;
+let cachedDangerouslyBypassSupport: boolean | null = null;
+
 let cachedOutputFormatSupport: boolean | null = null;
 let cachedVerboseSupport: boolean | null = null;
 let cachedDangerouslySkipPermissionsSupport: boolean | null = null;
@@ -58,7 +67,100 @@ function getCodexCliHelpText(): string | null {
   return null;
 }
 
-export function shouldUseOutputFormatFlag(): boolean {
+function getCodexExecHelpText(): string | null {
+  if (execHelpDetectionAttempted) {
+    return cachedExecHelpText;
+  }
+
+  execHelpDetectionAttempted = true;
+
+  try {
+    const command = new Deno.Command("codex", {
+      args: ["exec", "--help"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { code, stdout } = command.outputSync();
+    if (code === 0) {
+      cachedExecHelpText = decoder.decode(stdout);
+      return cachedExecHelpText;
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      cachedExecHelpText = null;
+      return null;
+    }
+  }
+
+  cachedExecHelpText = null;
+  return null;
+}
+
+export function supportsExecJsonMode(): boolean {
+  if (cachedExecJsonSupport !== null) {
+    return cachedExecJsonSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedExecJsonSupport = helpText.includes("--json") ||
+      helpText.includes("--experimental-json");
+    return cachedExecJsonSupport;
+  }
+
+  // CLIが利用できない場合は最新仕様を前提にtrueとする
+  cachedExecJsonSupport = true;
+  return cachedExecJsonSupport;
+}
+
+export function supportsExecColorFlag(): boolean {
+  if (cachedExecColorSupport !== null) {
+    return cachedExecColorSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedExecColorSupport = helpText.includes("--color");
+    return cachedExecColorSupport;
+  }
+
+  cachedExecColorSupport = true;
+  return cachedExecColorSupport;
+}
+
+export function supportsExecResumeSubcommand(): boolean {
+  if (cachedExecResumeSupport !== null) {
+    return cachedExecResumeSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedExecResumeSupport = helpText.includes("resume");
+    return cachedExecResumeSupport;
+  }
+
+  cachedExecResumeSupport = true;
+  return cachedExecResumeSupport;
+}
+
+export function supportsDangerouslyBypassFlag(): boolean {
+  if (cachedDangerouslyBypassSupport !== null) {
+    return cachedDangerouslyBypassSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedDangerouslyBypassSupport = helpText.includes(
+      "--dangerously-bypass-approvals-and-sandbox",
+    );
+    return cachedDangerouslyBypassSupport;
+  }
+
+  cachedDangerouslyBypassSupport = true;
+  return cachedDangerouslyBypassSupport;
+}
+
+export function supportsLegacyOutputFormatFlag(): boolean {
   const envOverride = getEnvOverride();
   if (envOverride !== null) {
     cachedOutputFormatSupport = envOverride;
@@ -75,7 +177,6 @@ export function shouldUseOutputFormatFlag(): boolean {
     return cachedOutputFormatSupport;
   }
 
-  // Codex CLIが存在しない場合などは従来の挙動を維持する
   cachedOutputFormatSupport = true;
   return cachedOutputFormatSupport;
 }
@@ -83,6 +184,14 @@ export function shouldUseOutputFormatFlag(): boolean {
 export function shouldUseVerboseFlag(): boolean {
   if (cachedVerboseSupport !== null) {
     return cachedVerboseSupport;
+  }
+
+  const execHelp = getCodexExecHelpText();
+  if (execHelp !== null) {
+    cachedVerboseSupport = execHelp.includes("--verbose");
+    if (cachedVerboseSupport) {
+      return true;
+    }
   }
 
   const helpText = getCodexCliHelpText();
@@ -100,6 +209,12 @@ export function shouldUseDangerouslySkipPermissionsFlag(): boolean {
     return cachedDangerouslySkipPermissionsSupport;
   }
 
+  const execHelp = getCodexExecHelpText();
+  if (execHelp !== null && execHelp.includes("--dangerously-skip-permissions")) {
+    cachedDangerouslySkipPermissionsSupport = true;
+    return true;
+  }
+
   const helpText = getCodexCliHelpText();
   if (helpText !== null) {
     cachedDangerouslySkipPermissionsSupport = helpText.includes(
@@ -112,12 +227,34 @@ export function shouldUseDangerouslySkipPermissionsFlag(): boolean {
   return cachedDangerouslySkipPermissionsSupport;
 }
 
-export function resetOutputFormatDetectionForTests(): void {
+export function resetCodexCliCapabilityCacheForTests(): void {
   cachedHelpText = null;
   helpDetectionAttempted = false;
+  cachedExecHelpText = null;
+  execHelpDetectionAttempted = false;
+  cachedExecJsonSupport = null;
+  cachedExecColorSupport = null;
+  cachedExecResumeSupport = null;
+  cachedDangerouslyBypassSupport = null;
   cachedOutputFormatSupport = null;
   cachedVerboseSupport = null;
   cachedDangerouslySkipPermissionsSupport = null;
+}
+
+export function recordExecJsonUnsupportedForTests(): void {
+  cachedExecJsonSupport = false;
+}
+
+export function recordExecColorUnsupportedForTests(): void {
+  cachedExecColorSupport = false;
+}
+
+export function recordExecResumeUnsupportedForTests(): void {
+  cachedExecResumeSupport = false;
+}
+
+export function recordDangerouslyBypassUnsupportedForTests(): void {
+  cachedDangerouslyBypassSupport = false;
 }
 
 export function recordVerboseFlagUnsupportedForTests(): void {

--- a/src/worker/codex-stream-processor-extract_test.ts
+++ b/src/worker/codex-stream-processor-extract_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import {
+  type CodexExecJsonEvent,
   type CodexStreamMessage,
   CodexStreamProcessor,
 } from "./codex-stream-processor.ts";
@@ -409,4 +410,70 @@ Deno.test("extractOutputMessage - 中程度の長さの結果を先頭末尾で�
   assertEquals(result?.includes("行10: 処理結果"), true);
   assertEquals(result?.includes("行省略"), true);
   assertEquals(result?.includes("行50: 処理結果"), true);
+});
+
+Deno.test("extractExecOutputUpdate - agent_message deltas are aggregated", () => {
+  const formatter = new MessageFormatter();
+  const processor = new CodexStreamProcessor(formatter);
+  const state = CodexStreamProcessor.createExecEventState();
+
+  const deltaEvent: CodexExecJsonEvent = {
+    type: "item.delta",
+    item: { id: "item_1", type: "agent_message", delta: { text: "こんにちは" } },
+  };
+
+  const deltaUpdate = processor.extractExecOutputUpdate(deltaEvent, state);
+  assertEquals(deltaUpdate?.aggregatedText, "こんにちは");
+  assertEquals(deltaUpdate?.isFinal, false);
+  assertEquals(deltaUpdate?.shouldDisplay, true);
+
+  const completeEvent: CodexExecJsonEvent = {
+    type: "item.completed",
+    item: { id: "item_1", type: "agent_message", text: "こんにちは！" },
+  };
+
+  const completeUpdate = processor.extractExecOutputUpdate(completeEvent, state);
+  assertEquals(completeUpdate?.aggregatedText, "こんにちは！");
+  assertEquals(completeUpdate?.isFinal, true);
+  assertEquals(completeUpdate?.shouldDisplay, true);
+});
+
+Deno.test("extractExecOutputUpdate - reasoning items are ignored", () => {
+  const formatter = new MessageFormatter();
+  const processor = new CodexStreamProcessor(formatter);
+  const state = CodexStreamProcessor.createExecEventState();
+
+  const reasoningEvent: CodexExecJsonEvent = {
+    type: "item.completed",
+    item: { id: "item_reason", type: "reasoning", text: "考え中" },
+  };
+
+  const update = processor.extractExecOutputUpdate(reasoningEvent, state);
+  assertEquals(update, null);
+});
+
+Deno.test("extractExecOutputUpdate - response completion exposes final text", () => {
+  const formatter = new MessageFormatter();
+  const processor = new CodexStreamProcessor(formatter);
+  const state = CodexStreamProcessor.createExecEventState();
+
+  const deltaEvent: CodexExecJsonEvent = {
+    type: "response.output_text.delta",
+    delta: { text: "Hello" },
+    response: { id: "resp_1" },
+  };
+
+  const deltaUpdate = processor.extractExecOutputUpdate(deltaEvent, state);
+  assertEquals(deltaUpdate?.aggregatedText, "Hello");
+  assertEquals(deltaUpdate?.shouldDisplay, false);
+
+  const completeEvent: CodexExecJsonEvent = {
+    type: "response.completed",
+    response: { id: "resp_1", output_text: "Hello" },
+  };
+
+  const completeUpdate = processor.extractExecOutputUpdate(completeEvent, state);
+  assertEquals(completeUpdate?.aggregatedText, "Hello");
+  assertEquals(completeUpdate?.shouldDisplay, true);
+  assertEquals(completeUpdate?.isFinal, true);
 });

--- a/src/worker/codex-stream-processor.ts
+++ b/src/worker/codex-stream-processor.ts
@@ -1,6 +1,13 @@
 import { MessageFormatter } from "./message-formatter.ts";
 import Anthropic from "npm:@anthropic-ai/sdk";
 
+const LEGACY_MESSAGE_TYPES = new Set([
+  "assistant",
+  "user",
+  "result",
+  "system",
+]);
+
 /**
  * JSON解析エラー
  */
@@ -107,6 +114,69 @@ export type CodexStreamMessage =
     permissionMode: "default" | "acceptEdits" | "bypassPermissions" | "plan";
   };
 
+export interface CodexExecUsage {
+  input_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+}
+
+export interface CodexExecItemContentBlock {
+  type?: string;
+  text?: string;
+  content?: CodexExecItemContentBlock[] | string;
+  [key: string]: unknown;
+}
+
+export interface CodexExecItem {
+  id?: string;
+  type?: string;
+  role?: string;
+  text?: string;
+  content?: CodexExecItemContentBlock[] | string;
+  delta?: { text?: string };
+  output_text?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface CodexExecResponse {
+  id?: string;
+  session_id?: string;
+  session?: { id?: string };
+  output?: CodexExecItemContentBlock[];
+  output_text?: string;
+  usage?: CodexExecUsage;
+  [key: string]: unknown;
+}
+
+export interface CodexExecJsonEvent {
+  type: string;
+  item?: CodexExecItem;
+  delta?: { text?: string };
+  response?: CodexExecResponse;
+  session?: { id?: string };
+  session_id?: string;
+  turn?: { id?: string; session_id?: string; session?: { id?: string } };
+  usage?: CodexExecUsage;
+  [key: string]: unknown;
+}
+
+export type CodexStreamEvent = CodexStreamMessage | CodexExecJsonEvent;
+
+export interface ExecEventState {
+  aggregates: Map<string, string>;
+}
+
+export interface ExecOutputUpdate {
+  aggregatedText: string;
+  deltaText?: string;
+  isFinal: boolean;
+  shouldDisplay: boolean;
+  itemType?: string;
+}
+
 export class CodexCodeRateLimitError extends Error {
   public readonly timestamp: number;
   public readonly retryAt: number;
@@ -129,20 +199,38 @@ export class CodexStreamProcessor {
     this.formatter = formatter;
   }
 
+  static createExecEventState(): ExecEventState {
+    return { aggregates: new Map<string, string>() };
+  }
+
   /**
    * JSONライン文字列を安全に解析して型検証を行う
    * @param line JSON文字列の行
-   * @returns パースされ、検証されたCodexStreamMessage
+   * @returns パースされ、検証されたCodexStreamEvent
    * @throws {JsonParseError} JSON解析に失敗した場合
    * @throws {SchemaValidationError} スキーマ検証に失敗した場合
    */
-  parseJsonLine(line: string): CodexStreamMessage {
+  parseJsonLine(line: string): CodexStreamEvent {
     // JSON解析
     try {
-      return JSON.parse(line) as CodexStreamMessage;
+      return JSON.parse(line) as CodexStreamEvent;
     } catch (error) {
       throw new JsonParseError(line, error);
     }
+  }
+
+  isLegacyMessage(event: CodexStreamEvent): event is CodexStreamMessage {
+    return typeof event === "object" && event !== null &&
+      "type" in event &&
+      typeof (event as { type: unknown }).type === "string" &&
+      LEGACY_MESSAGE_TYPES.has((event as { type: string }).type);
+  }
+
+  isExecJsonEvent(event: CodexStreamEvent): event is CodexExecJsonEvent {
+    return typeof event === "object" && event !== null &&
+      "type" in event &&
+      typeof (event as { type: unknown }).type === "string" &&
+      !LEGACY_MESSAGE_TYPES.has((event as { type: string }).type);
   }
 
   /**
@@ -214,25 +302,180 @@ export class CodexStreamProcessor {
   /**
    * JSONL行からCodex Codeの実際の出力メッセージを抽出する
    */
-  extractOutputMessage(parsed: CodexStreamMessage): string | null {
-    switch (parsed.type) {
-      case "assistant":
-        // assistantメッセージの処理
-        return this.extractAssistantMessage(parsed.message.content);
-      case "user":
-        // userメッセージの処理（tool_result等）
-        return this.extractUserMessage(parsed.message.content);
-      case "system":
-        // systemメッセージの処理（初期化情報）
-        return this.extractSystemMessage(parsed);
+  extractOutputMessage(parsed: CodexStreamEvent): string | null {
+    if (this.isLegacyMessage(parsed)) {
+      switch (parsed.type) {
+        case "assistant":
+          // assistantメッセージの処理
+          return this.extractAssistantMessage(parsed.message.content);
+        case "user":
+          // userメッセージの処理（tool_result等）
+          return this.extractUserMessage(parsed.message.content);
+        case "system":
+          // systemメッセージの処理（初期化情報）
+          return this.extractSystemMessage(parsed);
 
-      case "result":
-        // resultメッセージは最終結果として別途処理されるため、ここでは返さない
-        return null;
-
-      default:
-        throw new Error(parsed satisfies never);
+        case "result":
+          // resultメッセージは最終結果として別途処理されるため、ここでは返さない
+          return null;
+      }
     }
+
+    return null;
+  }
+
+  extractExecOutputUpdate(
+    event: CodexExecJsonEvent,
+    state: ExecEventState,
+  ): ExecOutputUpdate | null {
+    const eventType = event.type;
+
+    if (eventType.startsWith("item.")) {
+      if (!event.item) {
+        return null;
+      }
+
+      const itemId = event.item.id || "unknown";
+      const aggregateKey = `item:${itemId}`;
+      const previous = state.aggregates.get(aggregateKey) ?? "";
+      const extracted = this.extractItemAggregateText(event, previous);
+      if (!extracted) {
+        return null;
+      }
+
+      const { aggregate, delta, itemType } = extracted;
+      if (!aggregate) {
+        return null;
+      }
+
+      const normalizedType = (itemType || "").toLowerCase();
+      const isAgentMessage = normalizedType.includes("agent") ||
+        normalizedType.includes("assistant") ||
+        normalizedType === "message" ||
+        normalizedType === "output_text";
+      if (!isAgentMessage) {
+        return null;
+      }
+
+      const isFinalItem = eventType === "item.completed";
+      if (!isFinalItem && aggregate === previous) {
+        return null;
+      }
+
+      state.aggregates.set(aggregateKey, aggregate);
+
+      return {
+        aggregatedText: aggregate,
+        deltaText: delta,
+        isFinal: isFinalItem,
+        shouldDisplay: true,
+        itemType,
+      };
+    }
+
+    if (eventType.startsWith("response.")) {
+      const responseId = event.response?.id || "response";
+      const aggregateKey = `response:${responseId}`;
+      const previous = state.aggregates.get(aggregateKey) ?? "";
+      const aggregate = this.extractResponseText(event, previous);
+      if (!aggregate) {
+        return null;
+      }
+
+      const isFinalResponse = eventType === "response.completed";
+      if (!isFinalResponse && aggregate === previous) {
+        return null;
+      }
+
+      state.aggregates.set(aggregateKey, aggregate);
+      return {
+        aggregatedText: aggregate,
+        deltaText: aggregate.slice(previous.length) || undefined,
+        isFinal: isFinalResponse,
+        shouldDisplay: isFinalResponse,
+      };
+    }
+
+    return null;
+  }
+
+  private extractResponseText(
+    event: CodexExecJsonEvent,
+    previous: string,
+  ): string | null {
+    if (event.delta?.text) {
+      return previous + (event.delta.text || "").toString();
+    }
+
+    if (event.response?.output_text && typeof event.response.output_text === "string") {
+      return event.response.output_text;
+    }
+
+    if (Array.isArray(event.response?.output)) {
+      return this.collectExecBlocksText(event.response?.output);
+    }
+
+    return null;
+  }
+
+  private extractItemAggregateText(
+    event: CodexExecJsonEvent,
+    previous: string,
+  ): { aggregate: string; delta?: string; itemType?: string } | null {
+    const item = event.item;
+    if (!item) {
+      return null;
+    }
+
+    let aggregate = previous;
+    let delta: string | undefined;
+
+    if (item.delta?.text) {
+      delta = item.delta.text;
+    } else if (event.delta?.text) {
+      delta = event.delta.text;
+    }
+
+    if (typeof item.text === "string") {
+      aggregate = item.text;
+    } else if (typeof item.output_text === "string") {
+      aggregate = item.output_text;
+    } else if (typeof item.content === "string") {
+      aggregate = item.content;
+    } else if (Array.isArray(item.content)) {
+      aggregate = this.collectExecBlocksText(item.content);
+    }
+
+    if (!aggregate && delta) {
+      aggregate = previous + delta;
+    }
+
+    if (!aggregate) {
+      return null;
+    }
+
+    return { aggregate, delta, itemType: item.type };
+  }
+
+  private collectExecBlocksText(blocks: CodexExecItemContentBlock[]): string {
+    let result = "";
+    for (const block of blocks) {
+      if (!block) continue;
+      if (typeof block.text === "string") {
+        result += block.text;
+        continue;
+      }
+
+      if (Array.isArray(block.content)) {
+        result += this.collectExecBlocksText(block.content);
+        continue;
+      }
+
+      if (typeof block.content === "string") {
+        result += block.content;
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/worker/worker-configuration.ts
+++ b/src/worker/worker-configuration.ts
@@ -1,6 +1,9 @@
 import { CODEX_CLI } from "../constants.ts";
 import {
-  shouldUseOutputFormatFlag,
+  supportsExecColorFlag,
+  supportsExecJsonMode,
+  supportsDangerouslyBypassFlag,
+  supportsLegacyOutputFormatFlag,
   shouldUseVerboseFlag,
   shouldUseDangerouslySkipPermissionsFlag,
 } from "./codex-cli-capabilities.ts";
@@ -14,6 +17,9 @@ export class WorkerConfiguration {
   private translatorUrl?: string;
   private dangerouslySkipPermissions: boolean;
   private maxOutputTokens: number;
+  private useExecJsonMode: boolean;
+  private useExecColorFlag: boolean;
+  private useDangerouslyBypassFlag: boolean;
   private useOutputFormatFlag: boolean;
   private useCliVerboseFlag: boolean;
   private useDangerouslySkipPermissionsFlag: boolean;
@@ -29,9 +35,15 @@ export class WorkerConfiguration {
     this.appendSystemPrompt = appendSystemPrompt;
     this.translatorUrl = translatorUrl;
     this.dangerouslySkipPermissions = dangerouslySkipPermissions;
-    this.useOutputFormatFlag = shouldUseOutputFormatFlag();
+    this.useExecJsonMode = supportsExecJsonMode();
+    this.useExecColorFlag = this.useExecJsonMode && supportsExecColorFlag();
+    this.useDangerouslyBypassFlag = this.dangerouslySkipPermissions &&
+      this.useExecJsonMode && supportsDangerouslyBypassFlag();
+    this.useOutputFormatFlag = !this.useExecJsonMode &&
+      supportsLegacyOutputFormatFlag();
     this.useCliVerboseFlag = shouldUseVerboseFlag();
     this.useDangerouslySkipPermissionsFlag = this.dangerouslySkipPermissions &&
+      (!this.useExecJsonMode || !this.useDangerouslyBypassFlag) &&
       shouldUseDangerouslySkipPermissionsFlag();
 
     // 環境変数からトークン制限を取得、未設定の場合はデフォルト値を使用
@@ -69,13 +81,58 @@ export class WorkerConfiguration {
   }
 
   /**
+   * exec --jsonモードを使用するか
+   */
+  shouldUseExecJsonMode(): boolean {
+    return this.useExecJsonMode;
+  }
+
+  /**
+   * exec --jsonモードを無効化してレガシーモードへフォールバック
+   */
+  disableExecJsonMode(): void {
+    this.useExecJsonMode = false;
+    this.useExecColorFlag = false;
+    this.useDangerouslyBypassFlag = false;
+    this.useOutputFormatFlag = supportsLegacyOutputFormatFlag();
+    this.useDangerouslySkipPermissionsFlag = this.dangerouslySkipPermissions &&
+      shouldUseDangerouslySkipPermissionsFlag();
+  }
+
+  /**
+   * execモードでの--colorフラグを無効化
+   */
+  disableExecColorFlag(): void {
+    this.useExecColorFlag = false;
+  }
+
+  /**
+   * execモードでの危険フラグを無効化し、可能であれば旧フラグにフォールバック
+   */
+  disableDangerouslyBypassFlag(): void {
+    this.useDangerouslyBypassFlag = false;
+    if (this.dangerouslySkipPermissions) {
+      this.useDangerouslySkipPermissionsFlag = shouldUseDangerouslySkipPermissionsFlag();
+    }
+  }
+
+  /**
    * 権限チェックスキップ設定を設定する
    */
   setDangerouslySkipPermissions(skipPermissions: boolean): void {
     this.dangerouslySkipPermissions = skipPermissions;
-    this.useDangerouslySkipPermissionsFlag = skipPermissions
-      ? shouldUseDangerouslySkipPermissionsFlag()
-      : false;
+    if (skipPermissions) {
+      this.useDangerouslyBypassFlag = this.useExecJsonMode &&
+        supportsDangerouslyBypassFlag();
+      if (this.useDangerouslyBypassFlag) {
+        this.useDangerouslySkipPermissionsFlag = false;
+      } else {
+        this.useDangerouslySkipPermissionsFlag = shouldUseDangerouslySkipPermissionsFlag();
+      }
+    } else {
+      this.useDangerouslyBypassFlag = false;
+      this.useDangerouslySkipPermissionsFlag = false;
+    }
   }
 
   /**
@@ -121,33 +178,59 @@ export class WorkerConfiguration {
   buildCodexArgs(prompt: string, sessionId?: string | null): string[] {
     const args: string[] = [];
 
+    if (this.useExecJsonMode) {
+      args.push("exec");
+      args.push("--json");
+      if (this.useExecColorFlag) {
+        args.push("--color", "never");
+      }
+
+      if (this.verbose && this.useCliVerboseFlag) {
+        args.push("--verbose");
+      }
+
+      if (this.dangerouslySkipPermissions) {
+        if (this.useDangerouslyBypassFlag) {
+          args.push("--dangerously-bypass-approvals-and-sandbox");
+        } else if (this.useDangerouslySkipPermissionsFlag) {
+          args.push("--dangerously-skip-permissions");
+        }
+      }
+
+      if (this.appendSystemPrompt) {
+        args.push("--append-system-prompt", this.appendSystemPrompt);
+      }
+
+      if (sessionId) {
+        args.push("resume");
+        args.push(sessionId);
+      }
+
+      args.push(prompt);
+      return args;
+    }
+
     if (this.useOutputFormatFlag) {
       args.push("--output-format", "stream-json");
     }
 
-    // verboseモードかつCodex CLIがサポートしている場合のみ--verboseを追加
     if (this.verbose && this.useCliVerboseFlag) {
       args.push("--verbose");
     }
 
-    // セッション継続の場合
     if (sessionId) {
-      // args.push("--resume", sessionId);
       args.push("--continue");
     }
 
-    // 権限チェックスキップが有効な場合のみ
     if (this.dangerouslySkipPermissions && this.useDangerouslySkipPermissionsFlag) {
       args.push("--dangerously-skip-permissions");
     }
 
-    // append-system-promptが設定されている場合
     if (this.appendSystemPrompt) {
       args.push("--append-system-prompt", this.appendSystemPrompt);
     }
 
     args.push(prompt);
-
     return args;
   }
 

--- a/src/worker/worker-configuration_test.ts
+++ b/src/worker/worker-configuration_test.ts
@@ -1,9 +1,11 @@
 import { assertEquals } from "https://deno.land/std@0.211.0/assert/mod.ts";
 import { WorkerConfiguration } from "./worker-configuration.ts";
 import {
-  recordVerboseFlagUnsupportedForTests,
-  resetOutputFormatDetectionForTests,
+  recordDangerouslyBypassUnsupportedForTests,
   recordDangerouslySkipPermissionsUnsupportedForTests,
+  recordExecJsonUnsupportedForTests,
+  recordVerboseFlagUnsupportedForTests,
+  resetCodexCliCapabilityCacheForTests,
 } from "./codex-cli-capabilities.ts";
 
 Deno.test("WorkerConfiguration - 初期設定", () => {
@@ -35,20 +37,22 @@ Deno.test("WorkerConfiguration - verboseモード設定", () => {
 });
 
 Deno.test("WorkerConfiguration - buildCodexArgs - 基本", () => {
-  resetOutputFormatDetectionForTests();
+  resetCodexCliCapabilityCacheForTests();
   const config = new WorkerConfiguration();
   const args = config.buildCodexArgs("テストプロンプト");
 
   assertEquals(args, [
-    "--output-format",
-    "stream-json",
-    "--dangerously-skip-permissions",
+    "exec",
+    "--json",
+    "--color",
+    "never",
+    "--dangerously-bypass-approvals-and-sandbox",
     "テストプロンプト",
   ]);
 });
 
 Deno.test("WorkerConfiguration - buildCodexArgs - verboseモード", () => {
-  resetOutputFormatDetectionForTests();
+  resetCodexCliCapabilityCacheForTests();
   const config = new WorkerConfiguration(true);
   const args = config.buildCodexArgs("テストプロンプト");
 
@@ -59,14 +63,14 @@ Deno.test(
   "WorkerConfiguration - Codex CLIが--verboseをサポートしない場合にフラグを付与しない",
   () => {
     try {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
       recordVerboseFlagUnsupportedForTests();
       const config = new WorkerConfiguration(true);
       const args = config.buildCodexArgs("テストプロンプト");
 
       assertEquals(args.includes("--verbose"), false);
     } finally {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
     }
   },
 );
@@ -75,26 +79,30 @@ Deno.test(
   "WorkerConfiguration - Codex CLIが--dangerously-skip-permissionsをサポートしない場合にフラグを付与しない",
   () => {
     try {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
       recordDangerouslySkipPermissionsUnsupportedForTests();
       const config = new WorkerConfiguration();
       const args = config.buildCodexArgs("テストプロンプト");
 
-      assertEquals(args.includes("--dangerously-skip-permissions"), false);
+      assertEquals(args.includes("--dangerously-bypass-approvals-and-sandbox"), false);
     } finally {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
     }
   },
 );
 
-Deno.test.ignore(
+Deno.test(
   "WorkerConfiguration - buildCodexArgs - セッション継続",
   () => {
+    resetCodexCliCapabilityCacheForTests();
     const config = new WorkerConfiguration();
     const args = config.buildCodexArgs("テストプロンプト", "session-123");
 
-    assertEquals(args.includes("--resume"), true);
-    assertEquals(args.includes("session-123"), true);
+    assertEquals(args.slice(0, 2), ["exec", "--json"]);
+    const resumeIndex = args.indexOf("resume");
+    assertEquals(resumeIndex !== -1, true);
+    assertEquals(args[resumeIndex + 1], "session-123");
+    assertEquals(args[args.length - 1], "テストプロンプト");
   },
 );
 
@@ -119,14 +127,15 @@ Deno.test("WorkerConfiguration - buildCodexArgs - 空白を含む追加システ
 Deno.test("WorkerConfiguration - CODEX_CLI_OUTPUT_FORMAT_MODE=neverでフラグ無効", () => {
   try {
     Deno.env.set("CODEX_CLI_OUTPUT_FORMAT_MODE", "never");
-    resetOutputFormatDetectionForTests();
+    resetCodexCliCapabilityCacheForTests();
+    recordExecJsonUnsupportedForTests();
     const config = new WorkerConfiguration();
     const args = config.buildCodexArgs("テストプロンプト");
 
     assertEquals(args.includes("--output-format"), false);
   } finally {
     Deno.env.delete("CODEX_CLI_OUTPUT_FORMAT_MODE");
-    resetOutputFormatDetectionForTests();
+    resetCodexCliCapabilityCacheForTests();
   }
 });
 

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -4,10 +4,12 @@ import { PLaMoTranslator } from "../plamo-translator.ts";
 import { MessageFormatter } from "./message-formatter.ts";
 import {
   CodexCodeRateLimitError,
+  type CodexExecJsonEvent,
   type CodexStreamMessage,
   CodexStreamProcessor,
   JsonParseError,
   SchemaValidationError,
+  type ExecEventState,
 } from "./codex-stream-processor.ts";
 import { WorkerConfiguration } from "./worker-configuration.ts";
 import { SessionLogger } from "./session-logger.ts";
@@ -423,6 +425,7 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
     const streamProcessor = new CodexStreamProcessor(
       this.formatter,
     );
+    const execEventState = CodexStreamProcessor.createExecEventState();
 
     const processLine = (line: string) => {
       if (!line.trim()) return;
@@ -433,9 +436,10 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
         onProgress,
         { result, newSessionId },
         (updates) => {
-          result = updates.result || result;
-          newSessionId = updates.newSessionId || newSessionId;
+          result = updates.result ?? result;
+          newSessionId = updates.newSessionId ?? newSessionId;
         },
+        execEventState,
       );
     };
 
@@ -553,6 +557,7 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
       result?: string;
       newSessionId?: string | null;
     }) => void,
+    execEventState: ExecEventState,
   ): void {
     // 空行はスキップ
     if (!line.trim()) {
@@ -564,52 +569,65 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
       // 安全なJSON解析と型検証を使用
       const parsed = streamProcessor.parseJsonLine(line);
 
-      // メッセージタイプごとの処理
-      switch (parsed.type) {
-        case "result":
-          this.handleResultMessage(parsed, updateState);
-          break;
-        case "assistant":
-          this.handleAssistantMessage(parsed, state, updateState);
-          // assistantメッセージからトークン使用量を追跡
-          if (parsed.message?.usage && this.rateLimitManager) {
-            const usage = parsed.message.usage;
-            const inputTokens = usage.input_tokens +
-              (usage.cache_creation_input_tokens || 0) +
-              (usage.cache_read_input_tokens || 0);
-            const outputTokens = usage.output_tokens;
+      if (streamProcessor.isLegacyMessage(parsed)) {
+        // メッセージタイプごとの処理
+        switch (parsed.type) {
+          case "result":
+            this.handleResultMessage(parsed, updateState);
+            break;
+          case "assistant":
+            this.handleAssistantMessage(parsed, state, updateState);
+            // assistantメッセージからトークン使用量を追跡
+            if (parsed.message?.usage && this.rateLimitManager) {
+              const usage = parsed.message.usage;
+              const inputTokens = usage.input_tokens +
+                (usage.cache_creation_input_tokens || 0) +
+                (usage.cache_read_input_tokens || 0);
+              const outputTokens = usage.output_tokens;
 
-            this.rateLimitManager.trackTokenUsage(inputTokens, outputTokens);
-            this.logVerbose("トークン使用量を追跡", {
-              inputTokens,
-              outputTokens,
-              totalTokens: inputTokens + outputTokens,
-            });
-          }
-          break;
-      }
-
-      // Codex Codeの実際の出力内容をDiscordに送信
-      if (onProgress) {
-        const outputMessage = streamProcessor.extractOutputMessage(parsed);
-        if (outputMessage) {
-          // 最後のアクティビティを記録
-          this.lastActivityDescription = this.extractActivityDescription(
-            parsed,
-            outputMessage,
-          );
-          onProgress(this.formatter.formatResponse(outputMessage)).catch(
-            console.error,
-          );
+              this.rateLimitManager.trackTokenUsage(inputTokens, outputTokens);
+              this.logVerbose("トークン使用量を追跡", {
+                inputTokens,
+                outputTokens,
+                totalTokens: inputTokens + outputTokens,
+              });
+            }
+            break;
         }
+
+        // Codex Codeの実際の出力内容をDiscordに送信
+        if (onProgress) {
+          const outputMessage = streamProcessor.extractOutputMessage(parsed);
+          if (outputMessage) {
+            // 最後のアクティビティを記録
+            this.lastActivityDescription = this.extractActivityDescription(
+              parsed,
+              outputMessage,
+            );
+            onProgress(this.formatter.formatResponse(outputMessage)).catch(
+              console.error,
+            );
+          }
+        }
+
+        // セッションIDを更新
+        if (parsed.session_id) {
+          updateState({ newSessionId: parsed.session_id });
+          this.logVerbose("新しいセッションID取得", {
+            sessionId: parsed.session_id,
+          });
+        }
+        return;
       }
 
-      // セッションIDを更新
-      if (parsed.session_id) {
-        updateState({ newSessionId: parsed.session_id });
-        this.logVerbose("新しいセッションID取得", {
-          sessionId: parsed.session_id,
-        });
+      if (streamProcessor.isExecJsonEvent(parsed)) {
+        this.handleExecJsonEvent(
+          parsed,
+          streamProcessor,
+          onProgress,
+          updateState,
+          execEventState,
+        );
       }
     } catch (parseError) {
       if (parseError instanceof CodexCodeRateLimitError) {
@@ -741,6 +759,87 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
         }
       }
     }
+  }
+
+  private handleExecJsonEvent(
+    event: CodexExecJsonEvent,
+    streamProcessor: CodexStreamProcessor,
+    onProgress: ((content: string) => Promise<void>) | undefined,
+    updateState: (updates: { result?: string; newSessionId?: string | null }) => void,
+    execEventState: ExecEventState,
+  ): void {
+    const sessionId = this.extractSessionIdFromExecEvent(event);
+    if (sessionId) {
+      updateState({ newSessionId: sessionId });
+      if (sessionId !== this.state.sessionId) {
+        this.logVerbose("execモードで新しいセッションID取得", { sessionId });
+      }
+    }
+
+    const usage = this.extractUsageFromExecEvent(event);
+    if (usage && this.rateLimitManager) {
+      this.rateLimitManager.trackTokenUsage(usage.inputTokens, usage.outputTokens);
+      this.logVerbose("execモードでトークン使用量を追跡", {
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        totalTokens: usage.inputTokens + usage.outputTokens,
+      });
+    }
+
+    const update = streamProcessor.extractExecOutputUpdate(event, execEventState);
+    if (!update) {
+      return;
+    }
+
+    updateState({ result: update.aggregatedText });
+    this.lastActivityDescription = this.buildActivityDescriptionFromText(
+      update.aggregatedText,
+    );
+
+    if (update.shouldDisplay && onProgress) {
+      onProgress(this.formatter.formatResponse(update.aggregatedText)).catch(
+        console.error,
+      );
+    }
+  }
+
+  private extractSessionIdFromExecEvent(event: CodexExecJsonEvent): string | null {
+    const candidates = [
+      event.session_id,
+      event.session?.id,
+      event.response?.session_id,
+      event.response?.session?.id,
+      event.turn?.session_id,
+      event.turn?.session?.id,
+    ];
+
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  private extractUsageFromExecEvent(
+    event: CodexExecJsonEvent,
+  ): { inputTokens: number; outputTokens: number } | null {
+    const usages = [event.usage, event.response?.usage];
+
+    for (const usage of usages) {
+      if (!usage) continue;
+      const inputTokens = (usage.input_tokens || 0) +
+        (usage.cache_creation_input_tokens || 0) +
+        (usage.cache_read_input_tokens || 0) +
+        (usage.cached_input_tokens || 0);
+      const outputTokens = usage.output_tokens || 0;
+      if (inputTokens > 0 || outputTokens > 0) {
+        return { inputTokens, outputTokens };
+      }
+    }
+
+    return null;
   }
 
   private handleErrorMessage(
@@ -1317,13 +1416,24 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
       }
     }
 
-    // その他のメッセージの場合、最初の50文字を使用
+    // その他のメッセージの場合、テキストから説明を生成
     if (outputMessage) {
-      const preview = outputMessage.substring(0, 50);
-      return preview.length < outputMessage.length ? `${preview}...` : preview;
+      return this.buildActivityDescriptionFromText(outputMessage);
     }
 
     return "アクティビティ実行中";
+  }
+
+  private buildActivityDescriptionFromText(text: string): string {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return "アクティビティ実行中";
+    }
+    const firstLine = trimmed.split("\n")[0];
+    if (firstLine.length <= 50) {
+      return firstLine;
+    }
+    return `${firstLine.substring(0, 50)}...`;
   }
 
   /**

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -287,6 +287,43 @@ export class Worker implements IWorker {
           this.configuration.disableDangerouslySkipPermissionsFlag();
           continue;
         }
+
+        if (
+          ["--json", "exec", "resume"].includes(lastResult.error.option) &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logVerbose("Codex CLIのexec/jsonモードに非対応のためレガシーモードへ切り替え", {
+            option: lastResult.error.option,
+            stderr: lastResult.error.stderr,
+          });
+          this.configuration.disableExecJsonMode();
+          continue;
+        }
+
+        if (
+          lastResult.error.option === "--color" &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logVerbose("Codex CLIが--colorをサポートしていないためフラグを無効化", {
+            stderr: lastResult.error.stderr,
+          });
+          this.configuration.disableExecColorFlag();
+          continue;
+        }
+
+        if (
+          lastResult.error.option === "--dangerously-bypass-approvals-and-sandbox" &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logVerbose(
+            "Codex CLIが--dangerously-bypass-approvals-and-sandboxをサポートしていないため旧フラグへ切り替え",
+            {
+              stderr: lastResult.error.stderr,
+            },
+          );
+          this.configuration.disableDangerouslyBypassFlag();
+          continue;
+        }
       }
 
       if (
@@ -712,6 +749,93 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
     stdout: string,
   ): Result<never, WorkerError> {
     const stderrMessage = new TextDecoder().decode(stderr);
+
+    if (
+      stderrMessage.includes("unrecognized subcommand 'exec'") ||
+      stderrMessage.includes("unknown subcommand 'exec'") ||
+      (stderrMessage.includes("wasn't expected") &&
+        stderrMessage.includes("exec"))
+    ) {
+      this.logVerbose("Codex CLIがexecサブコマンドを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "exec",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes("unexpected argument '--json'") ||
+      stderrMessage.includes("unknown argument '--json'") ||
+      stderrMessage.includes("Found argument '--json'")
+    ) {
+      this.logVerbose("Codex CLIが--jsonを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "--json",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes("unexpected argument '--color'") ||
+      stderrMessage.includes("Found argument '--color'")
+    ) {
+      this.logVerbose("Codex CLIが--colorを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "--color",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes(
+        "unexpected argument '--dangerously-bypass-approvals-and-sandbox'",
+      ) ||
+      stderrMessage.includes(
+        "Found argument '--dangerously-bypass-approvals-and-sandbox'",
+      )
+    ) {
+      this.logVerbose(
+        "Codex CLIが--dangerously-bypass-approvals-and-sandboxを認識しないエラーを検出",
+        {
+          exitCode: code,
+          stderr: stderrMessage,
+        },
+      );
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "--dangerously-bypass-approvals-and-sandbox",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes("unrecognized subcommand 'resume'") ||
+      stderrMessage.includes("unknown subcommand 'resume'") ||
+      (stderrMessage.includes("wasn't expected") &&
+        stderrMessage.includes("resume"))
+    ) {
+      this.logVerbose("Codex CLIがexec resumeを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "resume",
+        stderr: stderrMessage,
+      });
+    }
 
     if (stderrMessage.includes("unexpected argument '--output-format'")) {
       this.logVerbose("Codex CLIが--output-formatを認識しないエラーを検出", {

--- a/src/worker_output_format_fallback_test.ts
+++ b/src/worker_output_format_fallback_test.ts
@@ -2,7 +2,13 @@ import { assertEquals } from "https://deno.land/std@0.214.0/assert/mod.ts";
 import { describe, it } from "https://deno.land/std@0.214.0/testing/bdd.ts";
 import { Worker } from "./worker/worker.ts";
 import { CodexCommandExecutor } from "./worker/codex-executor.ts";
-import { resetOutputFormatDetectionForTests } from "./worker/codex-cli-capabilities.ts";
+import {
+  recordDangerouslyBypassUnsupportedForTests,
+  recordExecJsonUnsupportedForTests,
+  recordVerboseFlagUnsupportedForTests,
+  recordDangerouslySkipPermissionsUnsupportedForTests,
+  resetCodexCliCapabilityCacheForTests,
+} from "./worker/codex-cli-capabilities.ts";
 import { WorkerState, WorkspaceManager } from "./workspace/workspace.ts";
 import { parseRepository } from "./git-utils.ts";
 import { ok } from "neverthrow";
@@ -59,6 +65,110 @@ class OutputFormatFallbackExecutor implements CodexCommandExecutor {
       })
     }\n`;
     _onData(encoder.encode(resultMessage));
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
+class ExecJsonFallbackExecutor implements CodexCommandExecutor {
+  attempts = 0;
+  argsHistory: string[][] = [];
+
+  async executeStreaming(
+    args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    this.attempts++;
+    this.argsHistory.push([...args]);
+    const encoder = new TextEncoder();
+
+    if (this.attempts === 1) {
+      const stderrMessage = "error: unexpected argument '--json' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    const sessionMessage = `${
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "test-session-id",
+        apiKeySource: "env",
+        cwd: ".",
+        tools: [],
+        mcp_servers: [],
+        model: "test-model",
+        permissionMode: "default",
+      })
+    }\n`;
+    onData(encoder.encode(sessionMessage));
+
+    const resultMessage = `${
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "ok",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        num_turns: 1,
+        session_id: "test-session-id",
+        total_cost_usd: 0,
+      })
+    }\n`;
+    onData(encoder.encode(resultMessage));
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
+class ExecColorFallbackExecutor implements CodexCommandExecutor {
+  attempts = 0;
+  argsHistory: string[][] = [];
+
+  async executeStreaming(
+    args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    this.attempts++;
+    this.argsHistory.push([...args]);
+    const encoder = new TextEncoder();
+
+    if (this.attempts === 1) {
+      const stderrMessage = "error: unexpected argument '--color' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    const sessionMessage = `${
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "test-session-id",
+        apiKeySource: "env",
+        cwd: ".",
+        tools: [],
+        mcp_servers: [],
+        model: "test-model",
+        permissionMode: "default",
+      })
+    }\n`;
+    onData(encoder.encode(sessionMessage));
+
+    const resultMessage = `${
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "ok",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        num_turns: 1,
+        session_id: "test-session-id",
+        total_cost_usd: 0,
+      })
+    }\n`;
+    onData(encoder.encode(resultMessage));
 
     return ok({ code: 0, stderr: new Uint8Array() });
   }
@@ -138,17 +248,22 @@ class MultipleFlagFallbackExecutor implements CodexCommandExecutor {
     const encoder = new TextEncoder();
 
     if (this.attempts === 1) {
+      const stderrMessage = "error: unexpected argument '--json' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    if (this.attempts === 2) {
       const stderrMessage =
         "error: unexpected argument '--output-format' found\n";
       return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
     }
 
-    if (this.attempts === 2) {
+    if (this.attempts === 3) {
       const stderrMessage = "error: unexpected argument '--verbose' found\n";
       return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
     }
 
-    if (this.attempts === 3) {
+    if (this.attempts === 4) {
       const stderrMessage =
         "error: unexpected argument '--dangerously-skip-permissions' found\n";
       return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
@@ -208,6 +323,59 @@ class DangerouslySkipPermissionsFallbackExecutor implements CodexCommandExecutor
     if (this.attempts === 1) {
       const stderrMessage =
         "error: unexpected argument '--dangerously-skip-permissions' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    const sessionMessage = `${
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "test-session-id",
+        apiKeySource: "env",
+        cwd: ".",
+        tools: [],
+        mcp_servers: [],
+        model: "test-model",
+        permissionMode: "default",
+      })
+    }\n`;
+    onData(encoder.encode(sessionMessage));
+
+    const resultMessage = `${
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "ok",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        num_turns: 1,
+        session_id: "test-session-id",
+        total_cost_usd: 0,
+      })
+    }\n`;
+    onData(encoder.encode(resultMessage));
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
+class DangerouslyBypassFallbackExecutor implements CodexCommandExecutor {
+  attempts = 0;
+  argsHistory: string[][] = [];
+
+  async executeStreaming(
+    args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    this.attempts++;
+    this.argsHistory.push([...args]);
+    const encoder = new TextEncoder();
+
+    if (this.attempts === 1) {
+      const stderrMessage =
+        "error: unexpected argument '--dangerously-bypass-approvals-and-sandbox' found\n";
       return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
     }
 
@@ -327,7 +495,8 @@ describe("Worker --output-format フラグ自動再試行", () => {
 
       const executor = new OutputFormatFallbackExecutor();
 
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
+      recordExecJsonUnsupportedForTests();
       const repoPath = await Deno.makeTempDir();
       const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
       await gitInit.output();
@@ -380,7 +549,144 @@ describe("Worker --output-format フラグ自動再試行", () => {
       }
     } finally {
       await Deno.remove(tempDir, { recursive: true });
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
+    }
+  });
+});
+
+describe("Worker exec --json フラグ自動再試行", () => {
+  it("Codex CLIが--jsonを拒否した場合に自動でレガシーモードへ切り替える", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const workspaceManager = new WorkspaceManager(tempDir);
+      await workspaceManager.initialize();
+
+      const executor = new ExecJsonFallbackExecutor();
+
+      resetCodexCliCapabilityCacheForTests();
+      const repoPath = await Deno.makeTempDir();
+      const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+      await gitInit.output();
+
+      try {
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "thread-id",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
+
+        const worker = new Worker(
+          state,
+          workspaceManager,
+          executor,
+          true,
+        );
+
+        const repositoryResult = parseRepository("test/repo");
+        if (repositoryResult.isOk()) {
+          await worker.setRepository(repositoryResult.value, repoPath);
+        }
+
+        worker.setUseDevcontainer(false);
+        Object.defineProperty(worker, "codexExecutor", {
+          value: executor,
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await worker.processMessage("テスト");
+        assertEquals(result.isOk(), true);
+        assertEquals(executor.attempts, 2);
+
+        const firstArgs = executor.argsHistory[0];
+        const secondArgs = executor.argsHistory[1];
+        assertEquals(firstArgs.includes("exec"), true);
+        assertEquals(firstArgs.includes("--json"), true);
+        assertEquals(secondArgs.includes("exec"), false);
+        assertEquals(secondArgs.includes("--output-format"), true);
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+      resetCodexCliCapabilityCacheForTests();
+    }
+  });
+});
+
+describe("Worker --color フラグ自動再試行", () => {
+  it("Codex CLIが--colorを拒否した場合に自動でフラグを無効化する", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const workspaceManager = new WorkspaceManager(tempDir);
+      await workspaceManager.initialize();
+
+      const executor = new ExecColorFallbackExecutor();
+
+      resetCodexCliCapabilityCacheForTests();
+      const repoPath = await Deno.makeTempDir();
+      const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+      await gitInit.output();
+
+      try {
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "thread-id",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
+
+        const worker = new Worker(
+          state,
+          workspaceManager,
+          executor,
+          true,
+        );
+
+        const repositoryResult = parseRepository("test/repo");
+        if (repositoryResult.isOk()) {
+          await worker.setRepository(repositoryResult.value, repoPath);
+        }
+
+        worker.setUseDevcontainer(false);
+        Object.defineProperty(worker, "codexExecutor", {
+          value: executor,
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await worker.processMessage("テスト");
+        assertEquals(result.isOk(), true);
+        assertEquals(executor.attempts, 2);
+
+        const firstArgs = executor.argsHistory[0];
+        const secondArgs = executor.argsHistory[1];
+        assertEquals(firstArgs.includes("--color"), true);
+        assertEquals(secondArgs.includes("--color"), false);
+        assertEquals(secondArgs.includes("exec"), true);
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+      resetCodexCliCapabilityCacheForTests();
     }
   });
 });
@@ -394,7 +700,7 @@ describe("Worker --verbose フラグ自動再試行", () => {
 
       const executor = new VerboseFallbackExecutor();
 
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
       const repoPath = await Deno.makeTempDir();
       const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
       await gitInit.output();
@@ -447,7 +753,7 @@ describe("Worker --verbose フラグ自動再試行", () => {
       }
     } finally {
       await Deno.remove(tempDir, { recursive: true });
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
     }
   });
 });
@@ -463,7 +769,79 @@ describe("Worker --dangerously-skip-permissions フラグ自動再試行", () =>
 
         const executor = new DangerouslySkipPermissionsFallbackExecutor();
 
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
+        recordDangerouslyBypassUnsupportedForTests();
+        const repoPath = await Deno.makeTempDir();
+        const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+        await gitInit.output();
+
+        try {
+          const state: WorkerState = {
+            workerName: "test-worker",
+            threadId: "thread-id",
+            devcontainerConfig: {
+              useDevcontainer: false,
+              useFallbackDevcontainer: false,
+              hasDevcontainerFile: false,
+              hasAnthropicsFeature: false,
+              isStarted: false,
+            },
+            status: "active",
+            createdAt: new Date().toISOString(),
+            lastActiveAt: new Date().toISOString(),
+          };
+
+          const worker = new Worker(
+            state,
+            workspaceManager,
+            executor,
+            true,
+          );
+
+          const repositoryResult = parseRepository("test/repo");
+          if (repositoryResult.isOk()) {
+            await worker.setRepository(repositoryResult.value, repoPath);
+          }
+
+          worker.setUseDevcontainer(false);
+          Object.defineProperty(worker, "codexExecutor", {
+            value: executor,
+            writable: true,
+            configurable: true,
+          });
+
+        const result = await worker.processMessage("テスト");
+        assertEquals(result.isOk(), true);
+        assertEquals(executor.attempts, 2);
+
+        const firstArgs = executor.argsHistory[0];
+        const secondArgs = executor.argsHistory[1];
+        assertEquals(firstArgs.includes("--dangerously-skip-permissions"), true);
+        assertEquals(secondArgs.includes("--dangerously-skip-permissions"), false);
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+        resetCodexCliCapabilityCacheForTests();
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+      resetCodexCliCapabilityCacheForTests();
+    }
+  },
+);
+});
+
+describe("Worker --dangerously-bypass フラグ自動再試行", () => {
+  it(
+    "Codex CLIが--dangerously-bypass-approvals-and-sandboxを拒否した場合に旧フラグへ切り替える",
+    async () => {
+      const tempDir = await Deno.makeTempDir();
+      try {
+        const workspaceManager = new WorkspaceManager(tempDir);
+        await workspaceManager.initialize();
+
+        const executor = new DangerouslyBypassFallbackExecutor();
+
+        resetCodexCliCapabilityCacheForTests();
         const repoPath = await Deno.makeTempDir();
         const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
         await gitInit.output();
@@ -509,15 +887,15 @@ describe("Worker --dangerously-skip-permissions フラグ自動再試行", () =>
 
           const firstArgs = executor.argsHistory[0];
           const secondArgs = executor.argsHistory[1];
-          assertEquals(firstArgs.includes("--dangerously-skip-permissions"), true);
-          assertEquals(secondArgs.includes("--dangerously-skip-permissions"), false);
+          assertEquals(firstArgs.includes("--dangerously-bypass-approvals-and-sandbox"), true);
+          assertEquals(secondArgs.includes("--dangerously-bypass-approvals-and-sandbox"), false);
+          assertEquals(secondArgs.includes("--dangerously-skip-permissions"), true);
         } finally {
           await Deno.remove(repoPath, { recursive: true });
-          resetOutputFormatDetectionForTests();
+          resetCodexCliCapabilityCacheForTests();
         }
       } finally {
         await Deno.remove(tempDir, { recursive: true });
-        resetOutputFormatDetectionForTests();
       }
     },
   );
@@ -534,7 +912,7 @@ describe("Worker Codex CLI TTYフォールバック", () => {
 
         const executor = new TtyFallbackExecutor();
 
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
         const repoPath = await Deno.makeTempDir();
         const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
         await gitInit.output();
@@ -581,10 +959,11 @@ describe("Worker Codex CLI TTYフォールバック", () => {
           assertEquals(executor.optionsHistory[1].usePty, true);
         } finally {
           await Deno.remove(repoPath, { recursive: true });
-          resetOutputFormatDetectionForTests();
+          resetCodexCliCapabilityCacheForTests();
         }
       } finally {
         await Deno.remove(tempDir, { recursive: true });
+        resetCodexCliCapabilityCacheForTests();
       }
     },
   );
@@ -592,7 +971,7 @@ describe("Worker Codex CLI TTYフォールバック", () => {
 
 describe("Worker Codex CLI互換フラグの多段再試行", () => {
   it(
-    "--output-format・--verbose・--dangerously-skip-permissionsが順に非対応でも順次無効化して成功する",
+    "--json・--output-format・--verbose・--dangerously-skip-permissionsが順に非対応でも順次無効化して成功する",
     async () => {
       const tempDir = await Deno.makeTempDir();
       try {
@@ -601,7 +980,7 @@ describe("Worker Codex CLI互換フラグの多段再試行", () => {
 
         const executor = new MultipleFlagFallbackExecutor();
 
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
         const repoPath = await Deno.makeTempDir();
         const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
         await gitInit.output();
@@ -643,46 +1022,36 @@ describe("Worker Codex CLI互換フラグの多段再試行", () => {
 
           const result = await worker.processMessage("テスト");
           assertEquals(result.isOk(), true);
-          assertEquals(executor.attempts, 4);
+          assertEquals(executor.attempts, 5);
 
           const firstArgs = executor.argsHistory[0];
           const secondArgs = executor.argsHistory[1];
           const thirdArgs = executor.argsHistory[2];
           const fourthArgs = executor.argsHistory[3];
+          const fifthArgs = executor.argsHistory[4];
 
-          assertEquals(firstArgs.includes("--output-format"), true);
-          assertEquals(firstArgs.includes("--verbose"), true);
-          assertEquals(
-            firstArgs.includes("--dangerously-skip-permissions"),
-            true,
-          );
+          assertEquals(firstArgs.includes("exec"), true);
+          assertEquals(firstArgs.includes("--json"), true);
 
-          assertEquals(secondArgs.includes("--output-format"), false);
+          assertEquals(secondArgs.includes("exec"), false);
+          assertEquals(secondArgs.includes("--output-format"), true);
           assertEquals(secondArgs.includes("--verbose"), true);
-          assertEquals(
-            secondArgs.includes("--dangerously-skip-permissions"),
-            true,
-          );
+          assertEquals(secondArgs.includes("--dangerously-skip-permissions"), true);
 
           assertEquals(thirdArgs.includes("--output-format"), false);
-          assertEquals(thirdArgs.includes("--verbose"), false);
-          assertEquals(
-            thirdArgs.includes("--dangerously-skip-permissions"),
-            true,
-          );
+          assertEquals(thirdArgs.includes("--verbose"), true);
+          assertEquals(thirdArgs.includes("--dangerously-skip-permissions"), true);
 
-          assertEquals(fourthArgs.includes("--output-format"), false);
           assertEquals(fourthArgs.includes("--verbose"), false);
-          assertEquals(
-            fourthArgs.includes("--dangerously-skip-permissions"),
-            false,
-          );
+          assertEquals(fourthArgs.includes("--dangerously-skip-permissions"), true);
+
+          assertEquals(fifthArgs.includes("--dangerously-skip-permissions"), false);
         } finally {
           await Deno.remove(repoPath, { recursive: true });
         }
       } finally {
         await Deno.remove(tempDir, { recursive: true });
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
       }
     },
   );


### PR DESCRIPTION
## Summary
- add capability detection helpers to prefer `codex exec --json` while keeping legacy fallbacks
- build Codex worker configuration around exec mode with graceful downgrades for unsupported flags
- expand worker CLI error handling and tests to cover new exec, color, and bypass fallback paths

## Testing
- `deno test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6903497d8a288330a853fc99a3673abe