### PR TITLE
Handle Codex exec JSON streams

### DIFF
--- a/src/worker/codex-cli-capabilities.ts
+++ b/src/worker/codex-cli-capabilities.ts
@@ -2,6 +2,15 @@ const decoder = new TextDecoder();
 
 let cachedHelpText: string | null = null;
 let helpDetectionAttempted = false;
+
+let cachedExecHelpText: string | null = null;
+let execHelpDetectionAttempted = false;
+
+let cachedExecJsonSupport: boolean | null = null;
+let cachedExecColorSupport: boolean | null = null;
+let cachedExecResumeSupport: boolean | null = null;
+let cachedDangerouslyBypassSupport: boolean | null = null;
+
 let cachedOutputFormatSupport: boolean | null = null;
 let cachedVerboseSupport: boolean | null = null;
 let cachedDangerouslySkipPermissionsSupport: boolean | null = null;
@@ -58,7 +67,100 @@ function getCodexCliHelpText(): string | null {
   return null;
 }
 
-export function shouldUseOutputFormatFlag(): boolean {
+function getCodexExecHelpText(): string | null {
+  if (execHelpDetectionAttempted) {
+    return cachedExecHelpText;
+  }
+
+  execHelpDetectionAttempted = true;
+
+  try {
+    const command = new Deno.Command("codex", {
+      args: ["exec", "--help"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { code, stdout } = command.outputSync();
+    if (code === 0) {
+      cachedExecHelpText = decoder.decode(stdout);
+      return cachedExecHelpText;
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      cachedExecHelpText = null;
+      return null;
+    }
+  }
+
+  cachedExecHelpText = null;
+  return null;
+}
+
+export function supportsExecJsonMode(): boolean {
+  if (cachedExecJsonSupport !== null) {
+    return cachedExecJsonSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedExecJsonSupport = helpText.includes("--json") ||
+      helpText.includes("--experimental-json");
+    return cachedExecJsonSupport;
+  }
+
+  // CLIが利用できない場合は最新仕様を前提にtrueとする
+  cachedExecJsonSupport = true;
+  return cachedExecJsonSupport;
+}
+
+export function supportsExecColorFlag(): boolean {
+  if (cachedExecColorSupport !== null) {
+    return cachedExecColorSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedExecColorSupport = helpText.includes("--color");
+    return cachedExecColorSupport;
+  }
+
+  cachedExecColorSupport = true;
+  return cachedExecColorSupport;
+}
+
+export function supportsExecResumeSubcommand(): boolean {
+  if (cachedExecResumeSupport !== null) {
+    return cachedExecResumeSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedExecResumeSupport = helpText.includes("resume");
+    return cachedExecResumeSupport;
+  }
+
+  cachedExecResumeSupport = true;
+  return cachedExecResumeSupport;
+}
+
+export function supportsDangerouslyBypassFlag(): boolean {
+  if (cachedDangerouslyBypassSupport !== null) {
+    return cachedDangerouslyBypassSupport;
+  }
+
+  const helpText = getCodexExecHelpText();
+  if (helpText !== null) {
+    cachedDangerouslyBypassSupport = helpText.includes(
+      "--dangerously-bypass-approvals-and-sandbox",
+    );
+    return cachedDangerouslyBypassSupport;
+  }
+
+  cachedDangerouslyBypassSupport = true;
+  return cachedDangerouslyBypassSupport;
+}
+
+export function supportsLegacyOutputFormatFlag(): boolean {
   const envOverride = getEnvOverride();
   if (envOverride !== null) {
     cachedOutputFormatSupport = envOverride;
@@ -75,7 +177,6 @@ export function shouldUseOutputFormatFlag(): boolean {
     return cachedOutputFormatSupport;
   }
 
-  // Codex CLIが存在しない場合などは従来の挙動を維持する
   cachedOutputFormatSupport = true;
   return cachedOutputFormatSupport;
 }
@@ -83,6 +184,14 @@ export function shouldUseOutputFormatFlag(): boolean {
 export function shouldUseVerboseFlag(): boolean {
   if (cachedVerboseSupport !== null) {
     return cachedVerboseSupport;
+  }
+
+  const execHelp = getCodexExecHelpText();
+  if (execHelp !== null) {
+    cachedVerboseSupport = execHelp.includes("--verbose");
+    if (cachedVerboseSupport) {
+      return true;
+    }
   }
 
   const helpText = getCodexCliHelpText();
@@ -100,6 +209,12 @@ export function shouldUseDangerouslySkipPermissionsFlag(): boolean {
     return cachedDangerouslySkipPermissionsSupport;
   }
 
+  const execHelp = getCodexExecHelpText();
+  if (execHelp !== null && execHelp.includes("--dangerously-skip-permissions")) {
+    cachedDangerouslySkipPermissionsSupport = true;
+    return true;
+  }
+
   const helpText = getCodexCliHelpText();
   if (helpText !== null) {
     cachedDangerouslySkipPermissionsSupport = helpText.includes(
@@ -112,12 +227,34 @@ export function shouldUseDangerouslySkipPermissionsFlag(): boolean {
   return cachedDangerouslySkipPermissionsSupport;
 }
 
-export function resetOutputFormatDetectionForTests(): void {
+export function resetCodexCliCapabilityCacheForTests(): void {
   cachedHelpText = null;
   helpDetectionAttempted = false;
+  cachedExecHelpText = null;
+  execHelpDetectionAttempted = false;
+  cachedExecJsonSupport = null;
+  cachedExecColorSupport = null;
+  cachedExecResumeSupport = null;
+  cachedDangerouslyBypassSupport = null;
   cachedOutputFormatSupport = null;
   cachedVerboseSupport = null;
   cachedDangerouslySkipPermissionsSupport = null;
+}
+
+export function recordExecJsonUnsupportedForTests(): void {
+  cachedExecJsonSupport = false;
+}
+
+export function recordExecColorUnsupportedForTests(): void {
+  cachedExecColorSupport = false;
+}
+
+export function recordExecResumeUnsupportedForTests(): void {
+  cachedExecResumeSupport = false;
+}
+
+export function recordDangerouslyBypassUnsupportedForTests(): void {
+  cachedDangerouslyBypassSupport = false;
 }
 
 export function recordVerboseFlagUnsupportedForTests(): void {

--- a/src/worker/codex-cli-capabilities.ts
+++ b/src/worker/codex-cli-capabilities.ts
@@ -10,6 +10,7 @@ let cachedExecJsonSupport: boolean | null = null;
 let cachedExecColorSupport: boolean | null = null;
 let cachedExecResumeSupport: boolean | null = null;
 let cachedDangerouslyBypassSupport: boolean | null = null;
+let cachedSearchFlagSupport: boolean | null = null;
 
 let cachedOutputFormatSupport: boolean | null = null;
 let cachedVerboseSupport: boolean | null = null;
@@ -160,6 +161,21 @@ export function supportsDangerouslyBypassFlag(): boolean {
   return cachedDangerouslyBypassSupport;
 }
 
+export function supportsSearchFlag(): boolean {
+  if (cachedSearchFlagSupport !== null) {
+    return cachedSearchFlagSupport;
+  }
+
+  const helpText = getCodexCliHelpText();
+  if (helpText !== null) {
+    cachedSearchFlagSupport = helpText.includes("--search");
+    return cachedSearchFlagSupport;
+  }
+
+  cachedSearchFlagSupport = true;
+  return cachedSearchFlagSupport;
+}
+
 export function supportsLegacyOutputFormatFlag(): boolean {
   const envOverride = getEnvOverride();
   if (envOverride !== null) {
@@ -236,6 +252,7 @@ export function resetCodexCliCapabilityCacheForTests(): void {
   cachedExecColorSupport = null;
   cachedExecResumeSupport = null;
   cachedDangerouslyBypassSupport = null;
+  cachedSearchFlagSupport = null;
   cachedOutputFormatSupport = null;
   cachedVerboseSupport = null;
   cachedDangerouslySkipPermissionsSupport = null;
@@ -263,4 +280,8 @@ export function recordVerboseFlagUnsupportedForTests(): void {
 
 export function recordDangerouslySkipPermissionsUnsupportedForTests(): void {
   cachedDangerouslySkipPermissionsSupport = false;
+}
+
+export function recordSearchFlagUnsupportedForTests(): void {
+  cachedSearchFlagSupport = false;
 }

--- a/src/worker/codex-stream-processor-extract_test.ts
+++ b/src/worker/codex-stream-processor-extract_test.ts
@@ -470,6 +470,44 @@ Deno.test(
 );
 
 Deno.test(
+  "extractSessionId - thread.startedイベントからthread_idを取得する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const event = {
+      type: "thread.started",
+      thread_id: "019a43e1-ffd3-78e1-b71e-5989534567b9",
+    } as unknown as CodexExecJsonEvent;
+
+    const sessionId = processor.extractSessionId(event);
+    assertEquals(sessionId, "019a43e1-ffd3-78e1-b71e-5989534567b9");
+  },
+);
+
+Deno.test(
+  "extractSessionId - thread情報がネストしていても検出する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const event = {
+      type: "turn.completed",
+      response: {
+        metadata: {
+          thread: {
+            id: "019a43e1-ffd3-78e1-b71e-5989534567b9",
+          },
+        },
+      },
+    } as unknown as CodexExecJsonEvent;
+
+    const sessionId = processor.extractSessionId(event);
+    assertEquals(sessionId, "019a43e1-ffd3-78e1-b71e-5989534567b9");
+  },
+);
+
+Deno.test(
   "extractSessionId - session_pathのみの場合はnullを返す",
   () => {
     const formatter = new MessageFormatter();
@@ -508,5 +546,17 @@ Deno.test(
     const text = "session_id: 1433408726685192193";
     const sessionId = processor.extractSessionIdFromText(text);
     assertEquals(sessionId, "1433408726685192193");
+  },
+);
+
+Deno.test(
+  "extractSessionIdFromText - thread id表記からセッションIDを抽出する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const text = "thread_id: 019a43e1-ffd3-78e1-b71e-5989534567b9";
+    const sessionId = processor.extractSessionIdFromText(text);
+    assertEquals(sessionId, "019a43e1-ffd3-78e1-b71e-5989534567b9");
   },
 );

--- a/src/worker/codex-stream-processor-extract_test.ts
+++ b/src/worker/codex-stream-processor-extract_test.ts
@@ -484,3 +484,29 @@ Deno.test(
     assertEquals(sessionId, null);
   },
 );
+
+Deno.test(
+  "extractSessionIdFromText - resumeヒントからセッションIDを抽出する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const text =
+      "To continue this session, run codex exec resume 019a34c2-258d-78d3-a3b6-3cdf971eee76";
+
+    const sessionId = processor.extractSessionIdFromText(text);
+    assertEquals(sessionId, "019a34c2-258d-78d3-a3b6-3cdf971eee76");
+  },
+);
+
+Deno.test(
+  "extractSessionIdFromText - session id表記からセッションIDを抽出する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const text = "session_id: 1433408726685192193";
+    const sessionId = processor.extractSessionIdFromText(text);
+    assertEquals(sessionId, "1433408726685192193");
+  },
+);

--- a/src/worker/codex-stream-processor-extract_test.ts
+++ b/src/worker/codex-stream-processor-extract_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import {
+  type CodexExecJsonEvent,
   type CodexStreamMessage,
   CodexStreamProcessor,
 } from "./codex-stream-processor.ts";
@@ -410,3 +411,76 @@ Deno.test("extractOutputMessage - 中程度の長さの結果を先頭末尾で�
   assertEquals(result?.includes("行省略"), true);
   assertEquals(result?.includes("行50: 処理結果"), true);
 });
+
+Deno.test(
+  "extractSessionId - response.session.id をフォールバックとして取得する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const event: CodexExecJsonEvent = {
+      type: "turn.completed",
+      response: {
+        session: {
+          id: "nested-session-id",
+          path: "/tmp/workspaces/nested-session-id",
+        },
+      },
+    };
+
+    const sessionId = processor.extractSessionId(event);
+    assertEquals(sessionId, "nested-session-id");
+  },
+);
+
+Deno.test(
+  "extractSessionId - sessionが文字列の場合も取得する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const event = {
+      type: "session.created",
+      session: "session-from-string",
+    } as unknown as CodexExecJsonEvent;
+
+    const sessionId = processor.extractSessionId(event);
+    assertEquals(sessionId, "session-from-string");
+  },
+);
+
+Deno.test(
+  "extractSessionId - session内の入れ子session_idも検出する",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const event = {
+      type: "turn.completed",
+      response: {
+        session: {
+          metadata: { session_id: "deep-session-id" },
+        },
+      },
+    } as unknown as CodexExecJsonEvent;
+
+    const sessionId = processor.extractSessionId(event);
+    assertEquals(sessionId, "deep-session-id");
+  },
+);
+
+Deno.test(
+  "extractSessionId - session_pathのみの場合はnullを返す",
+  () => {
+    const formatter = new MessageFormatter();
+    const processor = new CodexStreamProcessor(formatter);
+
+    const event = {
+      type: "turn.completed",
+      session_path: "/tmp/workspaces/only-path",
+    } as unknown as CodexExecJsonEvent;
+
+    const sessionId = processor.extractSessionId(event);
+    assertEquals(sessionId, null);
+  },
+);

--- a/src/worker/codex-stream-processor.ts
+++ b/src/worker/codex-stream-processor.ts
@@ -107,6 +107,84 @@ export type CodexStreamMessage =
     permissionMode: "default" | "acceptEdits" | "bypassPermissions" | "plan";
   };
 
+export type CodexExecItemContent =
+  | string
+  | {
+    type?: string;
+    text?: string;
+    text_delta?: string;
+    data?: string;
+  };
+
+export interface CodexExecItem {
+  id?: string;
+  type?: string;
+  text?: string;
+  delta?: string | { text?: string; text_delta?: string };
+  content?: CodexExecItemContent[];
+  output_text?: string | CodexExecItemContent[];
+  message?: string;
+  session_id?: string;
+  is_error?: boolean;
+}
+
+export interface CodexExecJsonEvent {
+  type: string;
+  item?: CodexExecItem;
+  session_id?: string;
+  session?: { id?: string };
+  result?: string;
+  response?: {
+    output_text?: string | CodexExecItemContent[];
+  };
+  usage?: {
+    input_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+    output_tokens?: number;
+    server_tool_use?: {
+      web_search_requests?: number;
+    };
+    service_tier?: string;
+  };
+  error?: { message?: string };
+  [key: string]: unknown;
+}
+
+export function isLegacyCodexStreamMessage(
+  value: unknown,
+): value is CodexStreamMessage {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const type = (value as { type?: unknown }).type;
+  if (typeof type !== "string") {
+    return false;
+  }
+
+  return ["assistant", "user", "result", "system"].includes(type);
+}
+
+export function isCodexExecJsonEvent(
+  value: unknown,
+): value is CodexExecJsonEvent {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const type = (value as { type?: unknown }).type;
+  if (typeof type !== "string") {
+    return false;
+  }
+
+  return type.startsWith("item.") ||
+    type.startsWith("turn.") ||
+    type.startsWith("response.") ||
+    type.startsWith("session.") ||
+    type.startsWith("error");
+}
+
 export class CodexCodeRateLimitError extends Error {
   public readonly timestamp: number;
   public readonly retryAt: number;
@@ -136,10 +214,10 @@ export class CodexStreamProcessor {
    * @throws {JsonParseError} JSON解析に失敗した場合
    * @throws {SchemaValidationError} スキーマ検証に失敗した場合
    */
-  parseJsonLine(line: string): CodexStreamMessage {
+  parseJsonLine(line: string): CodexStreamMessage | CodexExecJsonEvent {
     // JSON解析
     try {
-      return JSON.parse(line) as CodexStreamMessage;
+      return JSON.parse(line) as CodexStreamMessage | CodexExecJsonEvent;
     } catch (error) {
       throw new JsonParseError(line, error);
     }
@@ -214,25 +292,144 @@ export class CodexStreamProcessor {
   /**
    * JSONL行からCodex Codeの実際の出力メッセージを抽出する
    */
-  extractOutputMessage(parsed: CodexStreamMessage): string | null {
-    switch (parsed.type) {
-      case "assistant":
-        // assistantメッセージの処理
-        return this.extractAssistantMessage(parsed.message.content);
-      case "user":
-        // userメッセージの処理（tool_result等）
-        return this.extractUserMessage(parsed.message.content);
-      case "system":
-        // systemメッセージの処理（初期化情報）
-        return this.extractSystemMessage(parsed);
-
-      case "result":
-        // resultメッセージは最終結果として別途処理されるため、ここでは返さない
-        return null;
-
-      default:
-        throw new Error(parsed satisfies never);
+  extractOutputMessage(
+    parsed: CodexStreamMessage | CodexExecJsonEvent,
+  ): string | null {
+    if (isLegacyCodexStreamMessage(parsed)) {
+      switch (parsed.type) {
+        case "assistant":
+          return this.extractAssistantMessage(parsed.message.content);
+        case "user":
+          return this.extractUserMessage(parsed.message.content);
+        case "system":
+          return this.extractSystemMessage(parsed);
+        case "result":
+          return null;
+      }
+      return null;
     }
+
+    if (isCodexExecJsonEvent(parsed)) {
+      if (parsed.type.startsWith("item.")) {
+        const text = this.extractExecItemText(parsed.item);
+        if (!text) {
+          return null;
+        }
+
+        const itemType = parsed.item?.type;
+        switch (itemType) {
+          case "reasoning":
+            return `🤔 ${text}`;
+          case "tool_result":
+          case "tool_response":
+          case "command_result":
+            return `${parsed.item?.is_error ? "❌" : "✅"} **ツール実行結果:**\n${
+              this.formatter.formatToolResult(
+                text,
+                parsed.item?.is_error ?? false,
+              )
+            }`;
+          default:
+            return text;
+        }
+      }
+
+      if (parsed.type === "response.error" && parsed.error?.message) {
+        return `❌ Codexエラー: ${parsed.error.message}`;
+      }
+
+      if (parsed.type === "turn.completed" ||
+        parsed.type === "response.completed") {
+        return this.extractExecResponseText(parsed);
+      }
+    }
+
+    return null;
+  }
+
+  extractSessionId(
+    parsed: CodexStreamMessage | CodexExecJsonEvent,
+  ): string | null {
+    if (isLegacyCodexStreamMessage(parsed)) {
+      return parsed.session_id ?? null;
+    }
+
+    if (!isCodexExecJsonEvent(parsed)) {
+      return null;
+    }
+
+    if (typeof parsed.session_id === "string" && parsed.session_id) {
+      return parsed.session_id;
+    }
+
+    if (parsed.session && typeof parsed.session === "object") {
+      const sessionId = (parsed.session as { id?: unknown }).id;
+      if (typeof sessionId === "string" && sessionId) {
+        return sessionId;
+      }
+    }
+
+    if (parsed.item && typeof parsed.item.session_id === "string") {
+      return parsed.item.session_id;
+    }
+
+    return null;
+  }
+
+  extractUsageCounts(
+    parsed: CodexStreamMessage | CodexExecJsonEvent,
+  ): { inputTokens: number; outputTokens: number } | null {
+    const usage = isLegacyCodexStreamMessage(parsed) ? parsed.usage :
+      (isCodexExecJsonEvent(parsed) ? parsed.usage : undefined);
+
+    if (!usage) {
+      return null;
+    }
+
+    const inputTokens = (usage.input_tokens || 0) +
+      (usage.cache_creation_input_tokens || 0) +
+      (usage.cache_read_input_tokens || 0);
+    const outputTokens = usage.output_tokens || 0;
+
+    if (inputTokens === 0 && outputTokens === 0) {
+      return null;
+    }
+
+    return { inputTokens, outputTokens };
+  }
+
+  extractExecResponseText(parsed: CodexExecJsonEvent): string | null {
+    if (parsed.result && typeof parsed.result === "string") {
+      return parsed.result;
+    }
+
+    if (parsed.response?.output_text) {
+      const outputText = parsed.response.output_text;
+      if (typeof outputText === "string") {
+        return outputText;
+      }
+      if (Array.isArray(outputText)) {
+        const joined = outputText.map((item) => {
+          if (typeof item === "string") {
+            return item;
+          }
+          if (item && typeof item === "object") {
+            const text = (item as { text?: unknown }).text;
+            if (typeof text === "string") {
+              return text;
+            }
+            const textDelta = (item as { text_delta?: unknown }).text_delta;
+            if (typeof textDelta === "string") {
+              return textDelta;
+            }
+          }
+          return "";
+        }).join("");
+        return joined || null;
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -341,6 +538,91 @@ export class CodexStreamProcessor {
       return `🔧 **システム初期化:** ツール: ${tools}, MCPサーバー: ${mcpServers}`;
     }
     return null;
+  }
+
+  private extractExecItemText(item?: CodexExecItem): string | null {
+    if (!item) {
+      return null;
+    }
+
+    const parts: string[] = [];
+
+    if (typeof item.text === "string") {
+      parts.push(item.text);
+    }
+
+    if (typeof item.delta === "string") {
+      parts.push(item.delta);
+    } else if (item.delta && typeof item.delta === "object") {
+      const deltaText = (item.delta as { text?: unknown }).text;
+      if (typeof deltaText === "string") {
+        parts.push(deltaText);
+      }
+      const deltaTextDelta = (item.delta as { text_delta?: unknown }).text_delta;
+      if (typeof deltaTextDelta === "string") {
+        parts.push(deltaTextDelta);
+      }
+    }
+
+    if (typeof item.message === "string") {
+      parts.push(item.message);
+    }
+
+    if (item.output_text) {
+      const output = item.output_text;
+      if (typeof output === "string") {
+        parts.push(output);
+      } else if (Array.isArray(output)) {
+        for (const entry of output) {
+          if (typeof entry === "string") {
+            parts.push(entry);
+          } else if (entry && typeof entry === "object") {
+            const text = (entry as { text?: unknown }).text;
+            if (typeof text === "string") {
+              parts.push(text);
+            }
+            const textDelta = (entry as { text_delta?: unknown }).text_delta;
+            if (typeof textDelta === "string") {
+              parts.push(textDelta);
+            }
+            const data = (entry as { data?: unknown }).data;
+            if (typeof data === "string") {
+              parts.push(data);
+            }
+          }
+        }
+      }
+    }
+
+    if (Array.isArray(item.content)) {
+      for (const content of item.content) {
+        if (typeof content === "string") {
+          parts.push(content);
+          continue;
+        }
+
+        if (content && typeof content === "object") {
+          const text = (content as { text?: unknown }).text;
+          if (typeof text === "string") {
+            parts.push(text);
+          }
+          const textDelta = (content as { text_delta?: unknown }).text_delta;
+          if (typeof textDelta === "string") {
+            parts.push(textDelta);
+          }
+          const data = (content as { data?: unknown }).data;
+          if (typeof data === "string") {
+            parts.push(data);
+          }
+        }
+      }
+    }
+
+    if (parts.length === 0) {
+      return null;
+    }
+
+    return parts.join("");
   }
 
   /**

--- a/src/worker/codex-stream-processor.ts
+++ b/src/worker/codex-stream-processor.ts
@@ -373,7 +373,7 @@ export class CodexStreamProcessor {
       return parsed.item.session_id;
     }
 
-    return null;
+    return this.findSessionIdRecursively(parsed);
   }
 
   extractUsageCounts(
@@ -642,6 +642,124 @@ export class CodexStreamProcessor {
     if (match) {
       return parseInt(match[1], 10);
     }
+    return null;
+  }
+
+  private normalizeSessionId(value: unknown): string | null {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+      if (/[\s/\\]/.test(trimmed)) {
+        return null;
+      }
+      return trimmed;
+    }
+
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? String(value) : null;
+    }
+
+    return null;
+  }
+
+  private findSessionIdRecursively(
+    value: unknown,
+    parentKey?: string,
+    grandparentKey?: string,
+  ): string | null {
+    const normalizedParent = parentKey?.toLowerCase();
+    const normalizedGrandparent = grandparentKey?.toLowerCase();
+
+    if (
+      typeof value === "string" ||
+      typeof value === "number"
+    ) {
+      if (
+        normalizedParent === "session" ||
+        normalizedParent === "session_id" ||
+        normalizedParent === "sessionid"
+      ) {
+        return this.normalizeSessionId(value);
+      }
+
+      if (
+        normalizedParent === "id" &&
+        normalizedGrandparent &&
+        normalizedGrandparent.includes("session")
+      ) {
+        return this.normalizeSessionId(value);
+      }
+
+      return null;
+    }
+
+    if (Array.isArray(value)) {
+      for (const element of value) {
+        const candidate = this.findSessionIdRecursively(
+          element,
+          parentKey,
+          grandparentKey,
+        );
+        if (candidate) {
+          return candidate;
+        }
+      }
+      return null;
+    }
+
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    for (const [key, child] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      const normalizedKey = key.toLowerCase();
+
+      if (
+        normalizedKey === "session" ||
+        normalizedKey === "session_id" ||
+        normalizedKey === "sessionid"
+      ) {
+        const candidate = this.findSessionIdRecursively(
+          child,
+          key,
+          parentKey,
+        );
+        if (candidate) {
+          return candidate;
+        }
+        continue;
+      }
+
+      if (
+        normalizedKey === "id" &&
+        normalizedParent &&
+        normalizedParent.includes("session")
+      ) {
+        const candidate = this.findSessionIdRecursively(
+          child,
+          key,
+          parentKey,
+        );
+        if (candidate) {
+          return candidate;
+        }
+        continue;
+      }
+
+      const candidate = this.findSessionIdRecursively(
+        child,
+        key,
+        parentKey,
+      );
+      if (candidate) {
+        return candidate;
+      }
+    }
+
     return null;
   }
 }

--- a/src/worker/codex-stream-processor.ts
+++ b/src/worker/codex-stream-processor.ts
@@ -182,6 +182,7 @@ export function isCodexExecJsonEvent(
     type.startsWith("turn.") ||
     type.startsWith("response.") ||
     type.startsWith("session.") ||
+    type.startsWith("thread.") ||
     type.startsWith("error");
 }
 
@@ -373,6 +374,13 @@ export class CodexStreamProcessor {
       return parsed.item.session_id;
     }
 
+    const threadId = this.normalizeSessionId(
+      (parsed as { thread_id?: unknown }).thread_id,
+    );
+    if (threadId) {
+      return threadId;
+    }
+
     return this.findSessionIdRecursively(parsed);
   }
 
@@ -390,6 +398,7 @@ export class CodexStreamProcessor {
       const patterns = [
         /\bcodex(?:\s+exec)?\s+resume\s+([0-9a-zA-Z][0-9a-zA-Z\-]{8,})\b/g,
         /\bsession(?:[_\s-]*id)?\s*[:=]\s*([0-9a-zA-Z][0-9a-zA-Z\-]{8,})\b/g,
+        /\bthread(?:[_\s-]*id)?\s*[:=]\s*([0-9a-zA-Z][0-9a-zA-Z\-]{8,})\b/g,
       ];
 
       for (const pattern of patterns) {
@@ -709,7 +718,9 @@ export class CodexStreamProcessor {
       if (
         normalizedParent === "session" ||
         normalizedParent === "session_id" ||
-        normalizedParent === "sessionid"
+        normalizedParent === "sessionid" ||
+        normalizedParent === "thread_id" ||
+        normalizedParent === "threadid"
       ) {
         return this.normalizeSessionId(value);
       }
@@ -717,7 +728,8 @@ export class CodexStreamProcessor {
       if (
         normalizedParent === "id" &&
         normalizedGrandparent &&
-        normalizedGrandparent.includes("session")
+        (normalizedGrandparent.includes("session") ||
+          normalizedGrandparent.includes("thread"))
       ) {
         return this.normalizeSessionId(value);
       }
@@ -751,7 +763,10 @@ export class CodexStreamProcessor {
       if (
         normalizedKey === "session" ||
         normalizedKey === "session_id" ||
-        normalizedKey === "sessionid"
+        normalizedKey === "sessionid" ||
+        normalizedKey === "thread" ||
+        normalizedKey === "thread_id" ||
+        normalizedKey === "threadid"
       ) {
         const candidate = this.findSessionIdRecursively(
           child,
@@ -767,7 +782,8 @@ export class CodexStreamProcessor {
       if (
         normalizedKey === "id" &&
         normalizedParent &&
-        normalizedParent.includes("session")
+        (normalizedParent.includes("session") ||
+          normalizedParent.includes("thread"))
       ) {
         const candidate = this.findSessionIdRecursively(
           child,

--- a/src/worker/codex-stream-processor.ts
+++ b/src/worker/codex-stream-processor.ts
@@ -376,6 +376,36 @@ export class CodexStreamProcessor {
     return this.findSessionIdRecursively(parsed);
   }
 
+  extractSessionIdFromText(text: string | null | undefined): string | null {
+    if (!text) {
+      return null;
+    }
+
+    const searchTargets = Array.isArray(text) ? text : [text];
+    for (const target of searchTargets) {
+      if (typeof target !== "string") {
+        continue;
+      }
+
+      const patterns = [
+        /\bcodex(?:\s+exec)?\s+resume\s+([0-9a-zA-Z][0-9a-zA-Z\-]{8,})\b/g,
+        /\bsession(?:[_\s-]*id)?\s*[:=]\s*([0-9a-zA-Z][0-9a-zA-Z\-]{8,})\b/g,
+      ];
+
+      for (const pattern of patterns) {
+        let match: RegExpExecArray | null;
+        while ((match = pattern.exec(target)) !== null) {
+          const candidate = this.normalizeSessionId(match[1]);
+          if (candidate) {
+            return candidate;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
   extractUsageCounts(
     parsed: CodexStreamMessage | CodexExecJsonEvent,
   ): { inputTokens: number; outputTokens: number } | null {

--- a/src/worker/worker-configuration.ts
+++ b/src/worker/worker-configuration.ts
@@ -3,6 +3,7 @@ import {
   supportsExecColorFlag,
   supportsExecJsonMode,
   supportsDangerouslyBypassFlag,
+  supportsSearchFlag,
   supportsLegacyOutputFormatFlag,
   shouldUseVerboseFlag,
   shouldUseDangerouslySkipPermissionsFlag,
@@ -23,6 +24,7 @@ export class WorkerConfiguration {
   private useOutputFormatFlag: boolean;
   private useCliVerboseFlag: boolean;
   private useDangerouslySkipPermissionsFlag: boolean;
+  private useSearchFlag: boolean;
 
   constructor(
     verbose = false,
@@ -39,6 +41,7 @@ export class WorkerConfiguration {
     this.useExecColorFlag = this.useExecJsonMode && supportsExecColorFlag();
     this.useDangerouslyBypassFlag = this.dangerouslySkipPermissions &&
       this.useExecJsonMode && supportsDangerouslyBypassFlag();
+    this.useSearchFlag = supportsSearchFlag();
     this.useOutputFormatFlag = !this.useExecJsonMode &&
       supportsLegacyOutputFormatFlag();
     this.useCliVerboseFlag = shouldUseVerboseFlag();
@@ -178,6 +181,10 @@ export class WorkerConfiguration {
   buildCodexArgs(prompt: string, sessionId?: string | null): string[] {
     const args: string[] = [];
 
+    if (this.useSearchFlag) {
+      args.push("--search");
+    }
+
     if (this.useExecJsonMode) {
       args.push("exec");
       args.push("--json");
@@ -274,6 +281,10 @@ export class WorkerConfiguration {
    */
   disableDangerouslySkipPermissionsFlag(): void {
     this.useDangerouslySkipPermissionsFlag = false;
+  }
+
+  disableSearchFlag(): void {
+    this.useSearchFlag = false;
   }
 
   /**

--- a/src/worker/worker-configuration.ts
+++ b/src/worker/worker-configuration.ts
@@ -1,6 +1,9 @@
 import { CODEX_CLI } from "../constants.ts";
 import {
-  shouldUseOutputFormatFlag,
+  supportsExecColorFlag,
+  supportsExecJsonMode,
+  supportsDangerouslyBypassFlag,
+  supportsLegacyOutputFormatFlag,
   shouldUseVerboseFlag,
   shouldUseDangerouslySkipPermissionsFlag,
 } from "./codex-cli-capabilities.ts";
@@ -14,6 +17,9 @@ export class WorkerConfiguration {
   private translatorUrl?: string;
   private dangerouslySkipPermissions: boolean;
   private maxOutputTokens: number;
+  private useExecJsonMode: boolean;
+  private useExecColorFlag: boolean;
+  private useDangerouslyBypassFlag: boolean;
   private useOutputFormatFlag: boolean;
   private useCliVerboseFlag: boolean;
   private useDangerouslySkipPermissionsFlag: boolean;
@@ -29,9 +35,15 @@ export class WorkerConfiguration {
     this.appendSystemPrompt = appendSystemPrompt;
     this.translatorUrl = translatorUrl;
     this.dangerouslySkipPermissions = dangerouslySkipPermissions;
-    this.useOutputFormatFlag = shouldUseOutputFormatFlag();
+    this.useExecJsonMode = supportsExecJsonMode();
+    this.useExecColorFlag = this.useExecJsonMode && supportsExecColorFlag();
+    this.useDangerouslyBypassFlag = this.dangerouslySkipPermissions &&
+      this.useExecJsonMode && supportsDangerouslyBypassFlag();
+    this.useOutputFormatFlag = !this.useExecJsonMode &&
+      supportsLegacyOutputFormatFlag();
     this.useCliVerboseFlag = shouldUseVerboseFlag();
     this.useDangerouslySkipPermissionsFlag = this.dangerouslySkipPermissions &&
+      (!this.useExecJsonMode || !this.useDangerouslyBypassFlag) &&
       shouldUseDangerouslySkipPermissionsFlag();
 
     // 環境変数からトークン制限を取得、未設定の場合はデフォルト値を使用
@@ -69,13 +81,58 @@ export class WorkerConfiguration {
   }
 
   /**
+   * exec --jsonモードを使用するか
+   */
+  shouldUseExecJsonMode(): boolean {
+    return this.useExecJsonMode;
+  }
+
+  /**
+   * exec --jsonモードを無効化してレガシーモードへフォールバック
+   */
+  disableExecJsonMode(): void {
+    this.useExecJsonMode = false;
+    this.useExecColorFlag = false;
+    this.useDangerouslyBypassFlag = false;
+    this.useOutputFormatFlag = supportsLegacyOutputFormatFlag();
+    this.useDangerouslySkipPermissionsFlag = this.dangerouslySkipPermissions &&
+      shouldUseDangerouslySkipPermissionsFlag();
+  }
+
+  /**
+   * execモードでの--colorフラグを無効化
+   */
+  disableExecColorFlag(): void {
+    this.useExecColorFlag = false;
+  }
+
+  /**
+   * execモードでの危険フラグを無効化し、可能であれば旧フラグにフォールバック
+   */
+  disableDangerouslyBypassFlag(): void {
+    this.useDangerouslyBypassFlag = false;
+    if (this.dangerouslySkipPermissions) {
+      this.useDangerouslySkipPermissionsFlag = shouldUseDangerouslySkipPermissionsFlag();
+    }
+  }
+
+  /**
    * 権限チェックスキップ設定を設定する
    */
   setDangerouslySkipPermissions(skipPermissions: boolean): void {
     this.dangerouslySkipPermissions = skipPermissions;
-    this.useDangerouslySkipPermissionsFlag = skipPermissions
-      ? shouldUseDangerouslySkipPermissionsFlag()
-      : false;
+    if (skipPermissions) {
+      this.useDangerouslyBypassFlag = this.useExecJsonMode &&
+        supportsDangerouslyBypassFlag();
+      if (this.useDangerouslyBypassFlag) {
+        this.useDangerouslySkipPermissionsFlag = false;
+      } else {
+        this.useDangerouslySkipPermissionsFlag = shouldUseDangerouslySkipPermissionsFlag();
+      }
+    } else {
+      this.useDangerouslyBypassFlag = false;
+      this.useDangerouslySkipPermissionsFlag = false;
+    }
   }
 
   /**
@@ -121,33 +178,59 @@ export class WorkerConfiguration {
   buildCodexArgs(prompt: string, sessionId?: string | null): string[] {
     const args: string[] = [];
 
+    if (this.useExecJsonMode) {
+      args.push("exec");
+      args.push("--json");
+      if (this.useExecColorFlag) {
+        args.push("--color", "never");
+      }
+
+      if (this.verbose && this.useCliVerboseFlag) {
+        args.push("--verbose");
+      }
+
+      if (this.dangerouslySkipPermissions) {
+        if (this.useDangerouslyBypassFlag) {
+          args.push("--dangerously-bypass-approvals-and-sandbox");
+        } else if (this.useDangerouslySkipPermissionsFlag) {
+          args.push("--dangerously-skip-permissions");
+        }
+      }
+
+      if (this.appendSystemPrompt) {
+        args.push("--append-system-prompt", this.appendSystemPrompt);
+      }
+
+      if (sessionId) {
+        args.push("resume");
+        args.push(sessionId);
+      }
+
+      args.push(prompt);
+      return args;
+    }
+
     if (this.useOutputFormatFlag) {
       args.push("--output-format", "stream-json");
     }
 
-    // verboseモードかつCodex CLIがサポートしている場合のみ--verboseを追加
     if (this.verbose && this.useCliVerboseFlag) {
       args.push("--verbose");
     }
 
-    // セッション継続の場合
     if (sessionId) {
-      // args.push("--resume", sessionId);
       args.push("--continue");
     }
 
-    // 権限チェックスキップが有効な場合のみ
     if (this.dangerouslySkipPermissions && this.useDangerouslySkipPermissionsFlag) {
       args.push("--dangerously-skip-permissions");
     }
 
-    // append-system-promptが設定されている場合
     if (this.appendSystemPrompt) {
       args.push("--append-system-prompt", this.appendSystemPrompt);
     }
 
     args.push(prompt);
-
     return args;
   }
 

--- a/src/worker/worker-configuration_test.ts
+++ b/src/worker/worker-configuration_test.ts
@@ -1,9 +1,11 @@
 import { assertEquals } from "https://deno.land/std@0.211.0/assert/mod.ts";
 import { WorkerConfiguration } from "./worker-configuration.ts";
 import {
-  recordVerboseFlagUnsupportedForTests,
-  resetOutputFormatDetectionForTests,
+  recordDangerouslyBypassUnsupportedForTests,
   recordDangerouslySkipPermissionsUnsupportedForTests,
+  recordExecJsonUnsupportedForTests,
+  recordVerboseFlagUnsupportedForTests,
+  resetCodexCliCapabilityCacheForTests,
 } from "./codex-cli-capabilities.ts";
 
 Deno.test("WorkerConfiguration - 初期設定", () => {
@@ -35,20 +37,22 @@ Deno.test("WorkerConfiguration - verboseモード設定", () => {
 });
 
 Deno.test("WorkerConfiguration - buildCodexArgs - 基本", () => {
-  resetOutputFormatDetectionForTests();
+  resetCodexCliCapabilityCacheForTests();
   const config = new WorkerConfiguration();
   const args = config.buildCodexArgs("テストプロンプト");
 
   assertEquals(args, [
-    "--output-format",
-    "stream-json",
-    "--dangerously-skip-permissions",
+    "exec",
+    "--json",
+    "--color",
+    "never",
+    "--dangerously-bypass-approvals-and-sandbox",
     "テストプロンプト",
   ]);
 });
 
 Deno.test("WorkerConfiguration - buildCodexArgs - verboseモード", () => {
-  resetOutputFormatDetectionForTests();
+  resetCodexCliCapabilityCacheForTests();
   const config = new WorkerConfiguration(true);
   const args = config.buildCodexArgs("テストプロンプト");
 
@@ -59,14 +63,14 @@ Deno.test(
   "WorkerConfiguration - Codex CLIが--verboseをサポートしない場合にフラグを付与しない",
   () => {
     try {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
       recordVerboseFlagUnsupportedForTests();
       const config = new WorkerConfiguration(true);
       const args = config.buildCodexArgs("テストプロンプト");
 
       assertEquals(args.includes("--verbose"), false);
     } finally {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
     }
   },
 );
@@ -75,26 +79,30 @@ Deno.test(
   "WorkerConfiguration - Codex CLIが--dangerously-skip-permissionsをサポートしない場合にフラグを付与しない",
   () => {
     try {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
       recordDangerouslySkipPermissionsUnsupportedForTests();
       const config = new WorkerConfiguration();
       const args = config.buildCodexArgs("テストプロンプト");
 
-      assertEquals(args.includes("--dangerously-skip-permissions"), false);
+      assertEquals(args.includes("--dangerously-bypass-approvals-and-sandbox"), false);
     } finally {
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
     }
   },
 );
 
-Deno.test.ignore(
+Deno.test(
   "WorkerConfiguration - buildCodexArgs - セッション継続",
   () => {
+    resetCodexCliCapabilityCacheForTests();
     const config = new WorkerConfiguration();
     const args = config.buildCodexArgs("テストプロンプト", "session-123");
 
-    assertEquals(args.includes("--resume"), true);
-    assertEquals(args.includes("session-123"), true);
+    assertEquals(args.slice(0, 2), ["exec", "--json"]);
+    const resumeIndex = args.indexOf("resume");
+    assertEquals(resumeIndex !== -1, true);
+    assertEquals(args[resumeIndex + 1], "session-123");
+    assertEquals(args[args.length - 1], "テストプロンプト");
   },
 );
 
@@ -119,14 +127,15 @@ Deno.test("WorkerConfiguration - buildCodexArgs - 空白を含む追加システ
 Deno.test("WorkerConfiguration - CODEX_CLI_OUTPUT_FORMAT_MODE=neverでフラグ無効", () => {
   try {
     Deno.env.set("CODEX_CLI_OUTPUT_FORMAT_MODE", "never");
-    resetOutputFormatDetectionForTests();
+    resetCodexCliCapabilityCacheForTests();
+    recordExecJsonUnsupportedForTests();
     const config = new WorkerConfiguration();
     const args = config.buildCodexArgs("テストプロンプト");
 
     assertEquals(args.includes("--output-format"), false);
   } finally {
     Deno.env.delete("CODEX_CLI_OUTPUT_FORMAT_MODE");
-    resetOutputFormatDetectionForTests();
+    resetCodexCliCapabilityCacheForTests();
   }
 });
 

--- a/src/worker/worker-configuration_test.ts
+++ b/src/worker/worker-configuration_test.ts
@@ -4,6 +4,7 @@ import {
   recordDangerouslyBypassUnsupportedForTests,
   recordDangerouslySkipPermissionsUnsupportedForTests,
   recordExecJsonUnsupportedForTests,
+  recordSearchFlagUnsupportedForTests,
   recordVerboseFlagUnsupportedForTests,
   resetCodexCliCapabilityCacheForTests,
 } from "./codex-cli-capabilities.ts";
@@ -42,6 +43,7 @@ Deno.test("WorkerConfiguration - buildCodexArgs - 基本", () => {
   const args = config.buildCodexArgs("テストプロンプト");
 
   assertEquals(args, [
+    "--search",
     "exec",
     "--json",
     "--color",
@@ -98,7 +100,7 @@ Deno.test(
     const config = new WorkerConfiguration();
     const args = config.buildCodexArgs("テストプロンプト", "session-123");
 
-    assertEquals(args.slice(0, 2), ["exec", "--json"]);
+    assertEquals(args.slice(0, 3), ["--search", "exec", "--json"]);
     const resumeIndex = args.indexOf("resume");
     assertEquals(resumeIndex !== -1, true);
     assertEquals(args[resumeIndex + 1], "session-123");
@@ -135,6 +137,19 @@ Deno.test("WorkerConfiguration - CODEX_CLI_OUTPUT_FORMAT_MODE=neverでフラグ�
     assertEquals(args.includes("--output-format"), false);
   } finally {
     Deno.env.delete("CODEX_CLI_OUTPUT_FORMAT_MODE");
+    resetCodexCliCapabilityCacheForTests();
+  }
+});
+
+Deno.test("WorkerConfiguration - buildCodexArgs - --searchがサポートされない場合は付与しない", () => {
+  try {
+    resetCodexCliCapabilityCacheForTests();
+    recordSearchFlagUnsupportedForTests();
+    const config = new WorkerConfiguration();
+    const args = config.buildCodexArgs("テストプロンプト");
+
+    assertEquals(args.includes("--search"), false);
+  } finally {
     resetCodexCliCapabilityCacheForTests();
   }
 });

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -1004,16 +1004,14 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
     newSessionId: string | null,
     allOutput: string,
   ): Promise<void> {
+    const previousSessionId = this.state.sessionId ?? null;
     // セッションIDを更新
-    if (newSessionId) {
+    if (newSessionId && newSessionId !== previousSessionId) {
       this.state.sessionId = newSessionId;
       this.logVerbose("セッションID更新", {
-        oldSessionId: this.state.sessionId,
+        oldSessionId: previousSessionId,
         newSessionId,
       });
-
-      // 非同期でWorker状態を保存
-      this.saveAsync();
     }
 
     // 生のjsonlを保存
@@ -1030,6 +1028,9 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
         });
       }
     }
+
+    // 非同期でWorker状態を保存
+    this.saveAsync();
   }
 
   private handleStreamData(

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -503,6 +503,7 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
     }
 
     const { code, stderr } = executionResult.value;
+    const stderrMessage = new TextDecoder().decode(stderr);
 
     this.logVerbose("ストリーミング実行完了", {
       exitCode: code,
@@ -522,9 +523,31 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
       return this.handleErrorMessage(code, stderr, allOutput);
     }
 
+    if (!newSessionId) {
+      const stdoutSessionId = streamProcessor.extractSessionIdFromText(
+        allOutput,
+      );
+      if (stdoutSessionId) {
+        newSessionId = stdoutSessionId;
+        this.logVerbose("セッションID取得（stdoutフォールバック）", {
+          sessionId: stdoutSessionId,
+        });
+      } else {
+        const stderrSessionId = streamProcessor.extractSessionIdFromText(
+          stderrMessage,
+        );
+        if (stderrSessionId) {
+          newSessionId = stderrSessionId;
+          this.logVerbose("セッションID取得（stderrフォールバック）", {
+            sessionId: stderrSessionId,
+          });
+        }
+      }
+    }
+
     // VERBOSEモードで成功時のstderrも出力（警告等の情報がある場合）
     if (this.configuration.isVerbose() && stderr.length > 0) {
-      const stderrContent = new TextDecoder().decode(stderr);
+      const stderrContent = stderrMessage;
       if (stderrContent.trim()) {
         console.log(
           `[${

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -8,6 +8,9 @@ import {
   CodexStreamProcessor,
   JsonParseError,
   SchemaValidationError,
+  type CodexExecJsonEvent,
+  isLegacyCodexStreamMessage,
+  isCodexExecJsonEvent,
 } from "./codex-stream-processor.ts";
 import { WorkerConfiguration } from "./worker-configuration.ts";
 import { SessionLogger } from "./session-logger.ts";
@@ -287,6 +290,43 @@ export class Worker implements IWorker {
           this.configuration.disableDangerouslySkipPermissionsFlag();
           continue;
         }
+
+        if (
+          ["--json", "exec", "resume"].includes(lastResult.error.option) &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logVerbose("Codex CLIのexec/jsonモードに非対応のためレガシーモードへ切り替え", {
+            option: lastResult.error.option,
+            stderr: lastResult.error.stderr,
+          });
+          this.configuration.disableExecJsonMode();
+          continue;
+        }
+
+        if (
+          lastResult.error.option === "--color" &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logVerbose("Codex CLIが--colorをサポートしていないためフラグを無効化", {
+            stderr: lastResult.error.stderr,
+          });
+          this.configuration.disableExecColorFlag();
+          continue;
+        }
+
+        if (
+          lastResult.error.option === "--dangerously-bypass-approvals-and-sandbox" &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logVerbose(
+            "Codex CLIが--dangerously-bypass-approvals-and-sandboxをサポートしていないため旧フラグへ切り替え",
+            {
+              stderr: lastResult.error.stderr,
+            },
+          );
+          this.configuration.disableDangerouslyBypassFlag();
+          continue;
+        }
       }
 
       if (
@@ -524,39 +564,41 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
 
     this.logVerbose(`ストリーミング行処理: ${line}`);
     try {
-      // 安全なJSON解析と型検証を使用
       const parsed = streamProcessor.parseJsonLine(line);
 
-      // メッセージタイプごとの処理
-      switch (parsed.type) {
-        case "result":
-          this.handleResultMessage(parsed, updateState);
-          break;
-        case "assistant":
-          this.handleAssistantMessage(parsed, state, updateState);
-          // assistantメッセージからトークン使用量を追跡
-          if (parsed.message?.usage && this.rateLimitManager) {
-            const usage = parsed.message.usage;
-            const inputTokens = usage.input_tokens +
-              (usage.cache_creation_input_tokens || 0) +
-              (usage.cache_read_input_tokens || 0);
-            const outputTokens = usage.output_tokens;
+      if (isLegacyCodexStreamMessage(parsed)) {
+        switch (parsed.type) {
+          case "result":
+            this.handleResultMessage(parsed, updateState);
+            break;
+          case "assistant":
+            this.handleAssistantMessage(parsed, state, updateState);
+            if (parsed.message?.usage && this.rateLimitManager) {
+              const usage = parsed.message.usage;
+              const inputTokens = usage.input_tokens +
+                (usage.cache_creation_input_tokens || 0) +
+                (usage.cache_read_input_tokens || 0);
+              const outputTokens = usage.output_tokens;
 
-            this.rateLimitManager.trackTokenUsage(inputTokens, outputTokens);
-            this.logVerbose("トークン使用量を追跡", {
-              inputTokens,
-              outputTokens,
-              totalTokens: inputTokens + outputTokens,
-            });
-          }
-          break;
+              this.rateLimitManager.trackTokenUsage(
+                inputTokens,
+                outputTokens,
+              );
+              this.logVerbose("トークン使用量を追跡", {
+                inputTokens,
+                outputTokens,
+                totalTokens: inputTokens + outputTokens,
+              });
+            }
+            break;
+        }
+      } else if (isCodexExecJsonEvent(parsed)) {
+        this.handleExecJsonEvent(parsed, state, updateState, streamProcessor);
       }
 
-      // Codex Codeの実際の出力内容をDiscordに送信
       if (onProgress) {
         const outputMessage = streamProcessor.extractOutputMessage(parsed);
         if (outputMessage) {
-          // 最後のアクティビティを記録
           this.lastActivityDescription = this.extractActivityDescription(
             parsed,
             outputMessage,
@@ -567,11 +609,11 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
         }
       }
 
-      // セッションIDを更新
-      if (parsed.session_id) {
-        updateState({ newSessionId: parsed.session_id });
+      const sessionId = streamProcessor.extractSessionId(parsed);
+      if (sessionId) {
+        updateState({ newSessionId: sessionId });
         this.logVerbose("新しいセッションID取得", {
-          sessionId: parsed.session_id,
+          sessionId,
         });
       }
     } catch (parseError) {
@@ -661,6 +703,54 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
     }
   }
 
+  private handleExecJsonEvent(
+    parsed: CodexExecJsonEvent,
+    _state: { result: string; newSessionId: string | null },
+    updateState: (updates: { result?: string }) => void,
+    streamProcessor: CodexStreamProcessor,
+  ): void {
+    if (parsed.type === "item.completed" && parsed.item?.type === "agent_message") {
+      const message = streamProcessor.extractOutputMessage(parsed);
+      if (message) {
+        if (streamProcessor.isCodexCodeRateLimit(message)) {
+          const timestamp = streamProcessor.extractRateLimitTimestamp(message);
+          if (timestamp !== null) {
+            throw new CodexCodeRateLimitError(timestamp);
+          }
+        }
+        updateState({ result: message });
+      }
+    }
+
+    if (parsed.type === "turn.completed" || parsed.type === "response.completed") {
+      const finalMessage = streamProcessor.extractExecResponseText(parsed);
+      if (finalMessage) {
+        if (streamProcessor.isCodexCodeRateLimit(finalMessage)) {
+          const timestamp = streamProcessor.extractRateLimitTimestamp(finalMessage);
+          if (timestamp !== null) {
+            throw new CodexCodeRateLimitError(timestamp);
+          }
+        }
+        updateState({ result: finalMessage });
+      }
+    }
+
+    if (this.rateLimitManager) {
+      const usage = streamProcessor.extractUsageCounts(parsed);
+      if (usage) {
+        this.rateLimitManager.trackTokenUsage(
+          usage.inputTokens,
+          usage.outputTokens,
+        );
+        this.logVerbose("トークン使用量を追跡", {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          totalTokens: usage.inputTokens + usage.outputTokens,
+        });
+      }
+    }
+  }
+
   private handleResultMessage(
     parsed: CodexStreamMessage,
     updateState: (updates: { result?: string }) => void,
@@ -712,6 +802,93 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
     stdout: string,
   ): Result<never, WorkerError> {
     const stderrMessage = new TextDecoder().decode(stderr);
+
+    if (
+      stderrMessage.includes("unrecognized subcommand 'exec'") ||
+      stderrMessage.includes("unknown subcommand 'exec'") ||
+      (stderrMessage.includes("wasn't expected") &&
+        stderrMessage.includes("exec"))
+    ) {
+      this.logVerbose("Codex CLIがexecサブコマンドを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "exec",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes("unexpected argument '--json'") ||
+      stderrMessage.includes("unknown argument '--json'") ||
+      stderrMessage.includes("Found argument '--json'")
+    ) {
+      this.logVerbose("Codex CLIが--jsonを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "--json",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes("unexpected argument '--color'") ||
+      stderrMessage.includes("Found argument '--color'")
+    ) {
+      this.logVerbose("Codex CLIが--colorを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "--color",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes(
+        "unexpected argument '--dangerously-bypass-approvals-and-sandbox'",
+      ) ||
+      stderrMessage.includes(
+        "Found argument '--dangerously-bypass-approvals-and-sandbox'",
+      )
+    ) {
+      this.logVerbose(
+        "Codex CLIが--dangerously-bypass-approvals-and-sandboxを認識しないエラーを検出",
+        {
+          exitCode: code,
+          stderr: stderrMessage,
+        },
+      );
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "--dangerously-bypass-approvals-and-sandbox",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes("unrecognized subcommand 'resume'") ||
+      stderrMessage.includes("unknown subcommand 'resume'") ||
+      (stderrMessage.includes("wasn't expected") &&
+        stderrMessage.includes("resume"))
+    ) {
+      this.logVerbose("Codex CLIがexec resumeを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "resume",
+        stderr: stderrMessage,
+      });
+    }
 
     if (stderrMessage.includes("unexpected argument '--output-format'")) {
       this.logVerbose("Codex CLIが--output-formatを認識しないエラーを検出", {
@@ -1169,31 +1346,51 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
    * ストリームメッセージから最後のアクティビティの説明を抽出
    */
   private extractActivityDescription(
-    parsed: CodexStreamMessage,
+    parsed: CodexStreamMessage | CodexExecJsonEvent,
     outputMessage: string,
   ): string {
-    // ツール使用の場合
-    if (parsed.type === "assistant" && parsed.message?.content) {
-      for (const item of parsed.message.content) {
-        if (item.type === "tool_use" && item.name) {
-          return `ツール使用: ${item.name}`;
+    if (isLegacyCodexStreamMessage(parsed)) {
+      if (parsed.type === "assistant" && parsed.message?.content) {
+        for (const item of parsed.message.content) {
+          if (item.type === "tool_use" && item.name) {
+            return `ツール使用: ${item.name}`;
+          }
         }
+      }
+
+      if (parsed.type === "user" && parsed.message?.content) {
+        for (const item of parsed.message.content) {
+          if (typeof item === "string") {
+            return item;
+          }
+          if (item.type === "tool_result") {
+            return "ツール実行結果を処理";
+          }
+        }
+      }
+    } else if (isCodexExecJsonEvent(parsed)) {
+      if (parsed.type.startsWith("item.") && parsed.item) {
+        switch (parsed.item.type) {
+          case "reasoning":
+            return "思考中";
+          case "tool_result":
+          case "tool_response":
+          case "command_result":
+            return "ツール実行結果を処理";
+          case "agent_message":
+            break;
+          default:
+            if (parsed.item.type) {
+              return `イベント: ${parsed.item.type}`;
+            }
+        }
+      } else if (parsed.type === "turn.completed") {
+        return "ターン完了";
+      } else if (parsed.type === "response.completed") {
+        return "レスポンス完了";
       }
     }
 
-    // ツール結果の場合
-    if (parsed.type === "user" && parsed.message?.content) {
-      for (const item of parsed.message.content) {
-        if (typeof item === "string") {
-          return item;
-        }
-        if (item.type === "tool_result") {
-          return "ツール実行結果を処理";
-        }
-      }
-    }
-
-    // その他のメッセージの場合、最初の50文字を使用
     if (outputMessage) {
       const preview = outputMessage.substring(0, 50);
       return preview.length < outputMessage.length ? `${preview}...` : preview;

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -292,6 +292,17 @@ export class Worker implements IWorker {
         }
 
         if (
+          lastResult.error.option === "--search" &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logVerbose("Codex CLIが--searchをサポートしていないためフラグを無効化", {
+            stderr: lastResult.error.stderr,
+          });
+          this.configuration.disableSearchFlag();
+          continue;
+        }
+
+        if (
           ["--json", "exec", "resume"].includes(lastResult.error.option) &&
           attempt < maxAttempts - 1
         ) {
@@ -870,6 +881,21 @@ For research, analysis, or informational tasks, do not use the exit_plan_mode to
       return err({
         type: "CODEX_CLI_UNSUPPORTED_OPTION",
         option: "--color",
+        stderr: stderrMessage,
+      });
+    }
+
+    if (
+      stderrMessage.includes("unexpected argument '--search'") ||
+      stderrMessage.includes("Found argument '--search'")
+    ) {
+      this.logVerbose("Codex CLIが--searchを認識しないエラーを検出", {
+        exitCode: code,
+        stderr: stderrMessage,
+      });
+      return err({
+        type: "CODEX_CLI_UNSUPPORTED_OPTION",
+        option: "--search",
         stderr: stderrMessage,
       });
     }

--- a/src/worker_output_format_fallback_test.ts
+++ b/src/worker_output_format_fallback_test.ts
@@ -122,6 +122,36 @@ class ExecJsonFallbackExecutor implements CodexCommandExecutor {
   }
 }
 
+class SessionResumeHintExecutor implements CodexCommandExecutor {
+  async executeStreaming(
+    _args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+    _abortSignal?: AbortSignal,
+    _onProcessStart?: (childProcess: Deno.ChildProcess) => void,
+    _env?: Record<string, string>,
+    _options?: { usePty?: boolean },
+  ) {
+    const encoder = new TextEncoder();
+    const message = JSON.stringify({
+      type: "item.completed",
+      item: { type: "agent_message", id: "item_1", text: "完了しました" },
+    });
+    const turn = JSON.stringify({
+      type: "turn.completed",
+      usage: { input_tokens: 12, output_tokens: 4 },
+    });
+
+    onData(encoder.encode(`${message}\n`));
+    onData(encoder.encode(`${turn}\n`));
+
+    const hint =
+      "To continue this session, run codex exec resume 019a34c2-258d-78d3-a3b6-3cdf971eee76\n";
+
+    return ok({ code: 0, stderr: encoder.encode(hint) });
+  }
+}
+
 class ExecColorFallbackExecutor implements CodexCommandExecutor {
   attempts = 0;
   argsHistory: string[][] = [];
@@ -1171,6 +1201,59 @@ describe("Worker exec JSON agent message handling", () => {
       } finally {
         await Deno.remove(repoPath, { recursive: true });
       }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+});
+
+describe("Worker session resume hint fallback", () => {
+  it("stderrのresumeヒントからセッションIDを復元する", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const workspaceManager = new WorkspaceManager(tempDir);
+      await workspaceManager.initialize();
+
+      const executor = new SessionResumeHintExecutor();
+
+      const repoPath = `${tempDir}/repositories/test/repo`;
+      const worktreePath = `${tempDir}/worktrees/thread-123`;
+      await Deno.mkdir(repoPath, { recursive: true });
+      await Deno.mkdir(worktreePath, { recursive: true });
+
+      const state: WorkerState = {
+        workerName: "test-worker",
+        threadId: "thread-123",
+        repository: { fullName: "test/repo", org: "test", repo: "repo" },
+        repositoryLocalPath: repoPath,
+        worktreePath,
+        devcontainerConfig: {
+          useDevcontainer: false,
+          useFallbackDevcontainer: false,
+          hasDevcontainerFile: false,
+          hasAnthropicsFeature: false,
+          isStarted: false,
+        },
+        status: "active",
+        createdAt: new Date().toISOString(),
+        lastActiveAt: new Date().toISOString(),
+      };
+
+      const worker = new Worker(
+        state,
+        workspaceManager,
+        executor,
+        true,
+      );
+
+      const result = await worker.processMessage("ls");
+      assertEquals(result.isOk(), true);
+
+      const workerState = (worker as unknown as { state: WorkerState }).state;
+      assertEquals(
+        workerState.sessionId,
+        "019a34c2-258d-78d3-a3b6-3cdf971eee76",
+      );
     } finally {
       await Deno.remove(tempDir, { recursive: true });
     }

--- a/src/worker_output_format_fallback_test.ts
+++ b/src/worker_output_format_fallback_test.ts
@@ -204,6 +204,58 @@ class ExecColorFallbackExecutor implements CodexCommandExecutor {
   }
 }
 
+class SearchFlagFallbackExecutor implements CodexCommandExecutor {
+  attempts = 0;
+  argsHistory: string[][] = [];
+
+  async executeStreaming(
+    args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    this.attempts++;
+    this.argsHistory.push([...args]);
+    const encoder = new TextEncoder();
+
+    if (this.attempts === 1) {
+      const stderrMessage = "error: unexpected argument '--search' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    const sessionMessage = `${
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "test-session-id",
+        apiKeySource: "env",
+        cwd: ".",
+        tools: [],
+        mcp_servers: [],
+        model: "test-model",
+        permissionMode: "default",
+      })
+    }\n`;
+    onData(encoder.encode(sessionMessage));
+
+    const resultMessage = `${
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "ok",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        num_turns: 1,
+        session_id: "test-session-id",
+        total_cost_usd: 0,
+      })
+    }\n`;
+    onData(encoder.encode(resultMessage));
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
 class VerboseFallbackExecutor implements CodexCommandExecutor {
   attempts = 0;
   argsHistory: string[][] = [];
@@ -688,6 +740,74 @@ describe("Worker exec --json フラグ自動再試行", () => {
         assertEquals(firstArgs.includes("--json"), true);
         assertEquals(secondArgs.includes("exec"), false);
         assertEquals(secondArgs.includes("--output-format"), true);
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+      resetCodexCliCapabilityCacheForTests();
+    }
+  });
+});
+
+describe("Worker --search フラグ自動再試行", () => {
+  it("Codex CLIが--searchを拒否した場合に自動でフラグを無効化する", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const workspaceManager = new WorkspaceManager(tempDir);
+      await workspaceManager.initialize();
+
+      const executor = new SearchFlagFallbackExecutor();
+
+      resetCodexCliCapabilityCacheForTests();
+      const repoPath = await Deno.makeTempDir();
+      const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+      await gitInit.output();
+
+      try {
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "thread-id",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
+
+        const worker = new Worker(
+          state,
+          workspaceManager,
+          executor,
+          true,
+        );
+
+        const repositoryResult = parseRepository("test/repo");
+        if (repositoryResult.isOk()) {
+          await worker.setRepository(repositoryResult.value, repoPath);
+        }
+
+        worker.setUseDevcontainer(false);
+        Object.defineProperty(worker, "codexExecutor", {
+          value: executor,
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await worker.processMessage("テスト");
+        assertEquals(result.isOk(), true);
+        assertEquals(executor.attempts, 2);
+
+        const firstArgs = executor.argsHistory[0];
+        const secondArgs = executor.argsHistory[1];
+        assertEquals(firstArgs.includes("--search"), true);
+        assertEquals(secondArgs.includes("--search"), false);
+        assertEquals(secondArgs.includes("exec"), true);
       } finally {
         await Deno.remove(repoPath, { recursive: true });
       }

--- a/src/worker_output_format_fallback_test.ts
+++ b/src/worker_output_format_fallback_test.ts
@@ -2,7 +2,13 @@ import { assertEquals } from "https://deno.land/std@0.214.0/assert/mod.ts";
 import { describe, it } from "https://deno.land/std@0.214.0/testing/bdd.ts";
 import { Worker } from "./worker/worker.ts";
 import { CodexCommandExecutor } from "./worker/codex-executor.ts";
-import { resetOutputFormatDetectionForTests } from "./worker/codex-cli-capabilities.ts";
+import {
+  recordDangerouslyBypassUnsupportedForTests,
+  recordExecJsonUnsupportedForTests,
+  recordVerboseFlagUnsupportedForTests,
+  recordDangerouslySkipPermissionsUnsupportedForTests,
+  resetCodexCliCapabilityCacheForTests,
+} from "./worker/codex-cli-capabilities.ts";
 import { WorkerState, WorkspaceManager } from "./workspace/workspace.ts";
 import { parseRepository } from "./git-utils.ts";
 import { ok } from "neverthrow";
@@ -59,6 +65,110 @@ class OutputFormatFallbackExecutor implements CodexCommandExecutor {
       })
     }\n`;
     _onData(encoder.encode(resultMessage));
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
+class ExecJsonFallbackExecutor implements CodexCommandExecutor {
+  attempts = 0;
+  argsHistory: string[][] = [];
+
+  async executeStreaming(
+    args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    this.attempts++;
+    this.argsHistory.push([...args]);
+    const encoder = new TextEncoder();
+
+    if (this.attempts === 1) {
+      const stderrMessage = "error: unexpected argument '--json' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    const sessionMessage = `${
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "test-session-id",
+        apiKeySource: "env",
+        cwd: ".",
+        tools: [],
+        mcp_servers: [],
+        model: "test-model",
+        permissionMode: "default",
+      })
+    }\n`;
+    onData(encoder.encode(sessionMessage));
+
+    const resultMessage = `${
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "ok",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        num_turns: 1,
+        session_id: "test-session-id",
+        total_cost_usd: 0,
+      })
+    }\n`;
+    onData(encoder.encode(resultMessage));
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
+class ExecColorFallbackExecutor implements CodexCommandExecutor {
+  attempts = 0;
+  argsHistory: string[][] = [];
+
+  async executeStreaming(
+    args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    this.attempts++;
+    this.argsHistory.push([...args]);
+    const encoder = new TextEncoder();
+
+    if (this.attempts === 1) {
+      const stderrMessage = "error: unexpected argument '--color' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    const sessionMessage = `${
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "test-session-id",
+        apiKeySource: "env",
+        cwd: ".",
+        tools: [],
+        mcp_servers: [],
+        model: "test-model",
+        permissionMode: "default",
+      })
+    }\n`;
+    onData(encoder.encode(sessionMessage));
+
+    const resultMessage = `${
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "ok",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        num_turns: 1,
+        session_id: "test-session-id",
+        total_cost_usd: 0,
+      })
+    }\n`;
+    onData(encoder.encode(resultMessage));
 
     return ok({ code: 0, stderr: new Uint8Array() });
   }
@@ -138,17 +248,22 @@ class MultipleFlagFallbackExecutor implements CodexCommandExecutor {
     const encoder = new TextEncoder();
 
     if (this.attempts === 1) {
+      const stderrMessage = "error: unexpected argument '--json' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    if (this.attempts === 2) {
       const stderrMessage =
         "error: unexpected argument '--output-format' found\n";
       return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
     }
 
-    if (this.attempts === 2) {
+    if (this.attempts === 3) {
       const stderrMessage = "error: unexpected argument '--verbose' found\n";
       return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
     }
 
-    if (this.attempts === 3) {
+    if (this.attempts === 4) {
       const stderrMessage =
         "error: unexpected argument '--dangerously-skip-permissions' found\n";
       return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
@@ -245,6 +360,104 @@ class DangerouslySkipPermissionsFallbackExecutor implements CodexCommandExecutor
   }
 }
 
+class DangerouslyBypassFallbackExecutor implements CodexCommandExecutor {
+  attempts = 0;
+  argsHistory: string[][] = [];
+
+  async executeStreaming(
+    args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    this.attempts++;
+    this.argsHistory.push([...args]);
+    const encoder = new TextEncoder();
+
+    if (this.attempts === 1) {
+      const stderrMessage =
+        "error: unexpected argument '--dangerously-bypass-approvals-and-sandbox' found\n";
+      return ok({ code: 2, stderr: encoder.encode(stderrMessage) });
+    }
+
+    const sessionMessage = `${
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "test-session-id",
+        apiKeySource: "env",
+        cwd: ".",
+        tools: [],
+        mcp_servers: [],
+        model: "test-model",
+        permissionMode: "default",
+      })
+    }\n`;
+    onData(encoder.encode(sessionMessage));
+
+    const resultMessage = `${
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "ok",
+        duration_ms: 1,
+        duration_api_ms: 1,
+        is_error: false,
+        num_turns: 1,
+        session_id: "test-session-id",
+        total_cost_usd: 0,
+      })
+    }\n`;
+    onData(encoder.encode(resultMessage));
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
+class ExecJsonAgentMessageExecutor implements CodexCommandExecutor {
+  async executeStreaming(
+    _args: string[],
+    _cwd: string,
+    onData: (data: Uint8Array) => void,
+  ) {
+    const encoder = new TextEncoder();
+    const events = [
+      {
+        type: "item.completed",
+        item: {
+          id: "item_0",
+          type: "reasoning",
+          text: "Determining user's message count",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "item_1",
+          type: "agent_message",
+          text: "ユーザーとして送ったメッセージはこれで2通目です。",
+        },
+      },
+      {
+        type: "turn.completed",
+        session_id: "session-exec-json",
+        usage: {
+          input_tokens: 12,
+          output_tokens: 7,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+        result: "ユーザーとして送ったメッセージはこれで2通目です。",
+      },
+    ];
+
+    for (const event of events) {
+      onData(encoder.encode(`${JSON.stringify(event)}\n`));
+    }
+
+    return ok({ code: 0, stderr: new Uint8Array() });
+  }
+}
+
 class TtyFallbackExecutor implements CodexCommandExecutor {
   attempts = 0;
   optionsHistory: Array<{ usePty?: boolean }> = [];
@@ -327,7 +540,8 @@ describe("Worker --output-format フラグ自動再試行", () => {
 
       const executor = new OutputFormatFallbackExecutor();
 
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
+      recordExecJsonUnsupportedForTests();
       const repoPath = await Deno.makeTempDir();
       const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
       await gitInit.output();
@@ -380,7 +594,144 @@ describe("Worker --output-format フラグ自動再試行", () => {
       }
     } finally {
       await Deno.remove(tempDir, { recursive: true });
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
+    }
+  });
+});
+
+describe("Worker exec --json フラグ自動再試行", () => {
+  it("Codex CLIが--jsonを拒否した場合に自動でレガシーモードへ切り替える", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const workspaceManager = new WorkspaceManager(tempDir);
+      await workspaceManager.initialize();
+
+      const executor = new ExecJsonFallbackExecutor();
+
+      resetCodexCliCapabilityCacheForTests();
+      const repoPath = await Deno.makeTempDir();
+      const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+      await gitInit.output();
+
+      try {
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "thread-id",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
+
+        const worker = new Worker(
+          state,
+          workspaceManager,
+          executor,
+          true,
+        );
+
+        const repositoryResult = parseRepository("test/repo");
+        if (repositoryResult.isOk()) {
+          await worker.setRepository(repositoryResult.value, repoPath);
+        }
+
+        worker.setUseDevcontainer(false);
+        Object.defineProperty(worker, "codexExecutor", {
+          value: executor,
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await worker.processMessage("テスト");
+        assertEquals(result.isOk(), true);
+        assertEquals(executor.attempts, 2);
+
+        const firstArgs = executor.argsHistory[0];
+        const secondArgs = executor.argsHistory[1];
+        assertEquals(firstArgs.includes("exec"), true);
+        assertEquals(firstArgs.includes("--json"), true);
+        assertEquals(secondArgs.includes("exec"), false);
+        assertEquals(secondArgs.includes("--output-format"), true);
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+      resetCodexCliCapabilityCacheForTests();
+    }
+  });
+});
+
+describe("Worker --color フラグ自動再試行", () => {
+  it("Codex CLIが--colorを拒否した場合に自動でフラグを無効化する", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const workspaceManager = new WorkspaceManager(tempDir);
+      await workspaceManager.initialize();
+
+      const executor = new ExecColorFallbackExecutor();
+
+      resetCodexCliCapabilityCacheForTests();
+      const repoPath = await Deno.makeTempDir();
+      const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+      await gitInit.output();
+
+      try {
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "thread-id",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
+
+        const worker = new Worker(
+          state,
+          workspaceManager,
+          executor,
+          true,
+        );
+
+        const repositoryResult = parseRepository("test/repo");
+        if (repositoryResult.isOk()) {
+          await worker.setRepository(repositoryResult.value, repoPath);
+        }
+
+        worker.setUseDevcontainer(false);
+        Object.defineProperty(worker, "codexExecutor", {
+          value: executor,
+          writable: true,
+          configurable: true,
+        });
+
+        const result = await worker.processMessage("テスト");
+        assertEquals(result.isOk(), true);
+        assertEquals(executor.attempts, 2);
+
+        const firstArgs = executor.argsHistory[0];
+        const secondArgs = executor.argsHistory[1];
+        assertEquals(firstArgs.includes("--color"), true);
+        assertEquals(secondArgs.includes("--color"), false);
+        assertEquals(secondArgs.includes("exec"), true);
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+      resetCodexCliCapabilityCacheForTests();
     }
   });
 });
@@ -394,7 +745,7 @@ describe("Worker --verbose フラグ自動再試行", () => {
 
       const executor = new VerboseFallbackExecutor();
 
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
       const repoPath = await Deno.makeTempDir();
       const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
       await gitInit.output();
@@ -447,7 +798,7 @@ describe("Worker --verbose フラグ自動再試行", () => {
       }
     } finally {
       await Deno.remove(tempDir, { recursive: true });
-      resetOutputFormatDetectionForTests();
+      resetCodexCliCapabilityCacheForTests();
     }
   });
 });
@@ -463,7 +814,79 @@ describe("Worker --dangerously-skip-permissions フラグ自動再試行", () =>
 
         const executor = new DangerouslySkipPermissionsFallbackExecutor();
 
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
+        recordDangerouslyBypassUnsupportedForTests();
+        const repoPath = await Deno.makeTempDir();
+        const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+        await gitInit.output();
+
+        try {
+          const state: WorkerState = {
+            workerName: "test-worker",
+            threadId: "thread-id",
+            devcontainerConfig: {
+              useDevcontainer: false,
+              useFallbackDevcontainer: false,
+              hasDevcontainerFile: false,
+              hasAnthropicsFeature: false,
+              isStarted: false,
+            },
+            status: "active",
+            createdAt: new Date().toISOString(),
+            lastActiveAt: new Date().toISOString(),
+          };
+
+          const worker = new Worker(
+            state,
+            workspaceManager,
+            executor,
+            true,
+          );
+
+          const repositoryResult = parseRepository("test/repo");
+          if (repositoryResult.isOk()) {
+            await worker.setRepository(repositoryResult.value, repoPath);
+          }
+
+          worker.setUseDevcontainer(false);
+          Object.defineProperty(worker, "codexExecutor", {
+            value: executor,
+            writable: true,
+            configurable: true,
+          });
+
+        const result = await worker.processMessage("テスト");
+        assertEquals(result.isOk(), true);
+        assertEquals(executor.attempts, 2);
+
+        const firstArgs = executor.argsHistory[0];
+        const secondArgs = executor.argsHistory[1];
+        assertEquals(firstArgs.includes("--dangerously-skip-permissions"), true);
+        assertEquals(secondArgs.includes("--dangerously-skip-permissions"), false);
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+        resetCodexCliCapabilityCacheForTests();
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+      resetCodexCliCapabilityCacheForTests();
+    }
+  },
+);
+});
+
+describe("Worker --dangerously-bypass フラグ自動再試行", () => {
+  it(
+    "Codex CLIが--dangerously-bypass-approvals-and-sandboxを拒否した場合に旧フラグへ切り替える",
+    async () => {
+      const tempDir = await Deno.makeTempDir();
+      try {
+        const workspaceManager = new WorkspaceManager(tempDir);
+        await workspaceManager.initialize();
+
+        const executor = new DangerouslyBypassFallbackExecutor();
+
+        resetCodexCliCapabilityCacheForTests();
         const repoPath = await Deno.makeTempDir();
         const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
         await gitInit.output();
@@ -509,15 +932,15 @@ describe("Worker --dangerously-skip-permissions フラグ自動再試行", () =>
 
           const firstArgs = executor.argsHistory[0];
           const secondArgs = executor.argsHistory[1];
-          assertEquals(firstArgs.includes("--dangerously-skip-permissions"), true);
-          assertEquals(secondArgs.includes("--dangerously-skip-permissions"), false);
+          assertEquals(firstArgs.includes("--dangerously-bypass-approvals-and-sandbox"), true);
+          assertEquals(secondArgs.includes("--dangerously-bypass-approvals-and-sandbox"), false);
+          assertEquals(secondArgs.includes("--dangerously-skip-permissions"), true);
         } finally {
           await Deno.remove(repoPath, { recursive: true });
-          resetOutputFormatDetectionForTests();
+          resetCodexCliCapabilityCacheForTests();
         }
       } finally {
         await Deno.remove(tempDir, { recursive: true });
-        resetOutputFormatDetectionForTests();
       }
     },
   );
@@ -534,7 +957,7 @@ describe("Worker Codex CLI TTYフォールバック", () => {
 
         const executor = new TtyFallbackExecutor();
 
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
         const repoPath = await Deno.makeTempDir();
         const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
         await gitInit.output();
@@ -581,10 +1004,11 @@ describe("Worker Codex CLI TTYフォールバック", () => {
           assertEquals(executor.optionsHistory[1].usePty, true);
         } finally {
           await Deno.remove(repoPath, { recursive: true });
-          resetOutputFormatDetectionForTests();
+          resetCodexCliCapabilityCacheForTests();
         }
       } finally {
         await Deno.remove(tempDir, { recursive: true });
+        resetCodexCliCapabilityCacheForTests();
       }
     },
   );
@@ -592,7 +1016,7 @@ describe("Worker Codex CLI TTYフォールバック", () => {
 
 describe("Worker Codex CLI互換フラグの多段再試行", () => {
   it(
-    "--output-format・--verbose・--dangerously-skip-permissionsが順に非対応でも順次無効化して成功する",
+    "--json・--output-format・--verbose・--dangerously-skip-permissionsが順に非対応でも順次無効化して成功する",
     async () => {
       const tempDir = await Deno.makeTempDir();
       try {
@@ -601,7 +1025,7 @@ describe("Worker Codex CLI互換フラグの多段再試行", () => {
 
         const executor = new MultipleFlagFallbackExecutor();
 
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
         const repoPath = await Deno.makeTempDir();
         const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
         await gitInit.output();
@@ -643,47 +1067,112 @@ describe("Worker Codex CLI互換フラグの多段再試行", () => {
 
           const result = await worker.processMessage("テスト");
           assertEquals(result.isOk(), true);
-          assertEquals(executor.attempts, 4);
+          assertEquals(executor.attempts, 5);
 
           const firstArgs = executor.argsHistory[0];
           const secondArgs = executor.argsHistory[1];
           const thirdArgs = executor.argsHistory[2];
           const fourthArgs = executor.argsHistory[3];
+          const fifthArgs = executor.argsHistory[4];
 
-          assertEquals(firstArgs.includes("--output-format"), true);
-          assertEquals(firstArgs.includes("--verbose"), true);
-          assertEquals(
-            firstArgs.includes("--dangerously-skip-permissions"),
-            true,
-          );
+          assertEquals(firstArgs.includes("exec"), true);
+          assertEquals(firstArgs.includes("--json"), true);
 
-          assertEquals(secondArgs.includes("--output-format"), false);
+          assertEquals(secondArgs.includes("exec"), false);
+          assertEquals(secondArgs.includes("--output-format"), true);
           assertEquals(secondArgs.includes("--verbose"), true);
-          assertEquals(
-            secondArgs.includes("--dangerously-skip-permissions"),
-            true,
-          );
+          assertEquals(secondArgs.includes("--dangerously-skip-permissions"), true);
 
           assertEquals(thirdArgs.includes("--output-format"), false);
-          assertEquals(thirdArgs.includes("--verbose"), false);
-          assertEquals(
-            thirdArgs.includes("--dangerously-skip-permissions"),
-            true,
-          );
+          assertEquals(thirdArgs.includes("--verbose"), true);
+          assertEquals(thirdArgs.includes("--dangerously-skip-permissions"), true);
 
-          assertEquals(fourthArgs.includes("--output-format"), false);
           assertEquals(fourthArgs.includes("--verbose"), false);
-          assertEquals(
-            fourthArgs.includes("--dangerously-skip-permissions"),
-            false,
-          );
+          assertEquals(fourthArgs.includes("--dangerously-skip-permissions"), true);
+
+          assertEquals(fifthArgs.includes("--dangerously-skip-permissions"), false);
         } finally {
           await Deno.remove(repoPath, { recursive: true });
         }
       } finally {
         await Deno.remove(tempDir, { recursive: true });
-        resetOutputFormatDetectionForTests();
+        resetCodexCliCapabilityCacheForTests();
       }
     },
   );
+});
+
+
+describe("Worker exec JSON agent message handling", () => {
+  it("Codex execイベントからエージェントの応答を取り出す", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      const workspaceManager = new WorkspaceManager(tempDir);
+      await workspaceManager.initialize();
+
+      const executor = new ExecJsonAgentMessageExecutor();
+      const repoPath = await Deno.makeTempDir();
+      const gitInit = new Deno.Command("git", { args: ["init"], cwd: repoPath });
+      await gitInit.output();
+
+      try {
+        const state: WorkerState = {
+          workerName: "test-worker",
+          threadId: "thread-id",
+          devcontainerConfig: {
+            useDevcontainer: false,
+            useFallbackDevcontainer: false,
+            hasDevcontainerFile: false,
+            hasAnthropicsFeature: false,
+            isStarted: false,
+          },
+          status: "active",
+          createdAt: new Date().toISOString(),
+          lastActiveAt: new Date().toISOString(),
+        };
+
+        const worker = new Worker(
+          state,
+          workspaceManager,
+          executor,
+          true,
+        );
+
+        const repositoryResult = parseRepository("test/repo");
+        if (repositoryResult.isOk()) {
+          await worker.setRepository(repositoryResult.value, repoPath);
+        }
+
+        worker.setUseDevcontainer(false);
+
+        const progressMessages: string[] = [];
+        const result = await worker.processMessage(
+          "このメッセージなんこめ？",
+          async (content) => {
+            progressMessages.push(content);
+          },
+        );
+
+        assertEquals(result.isOk(), true);
+        if (result.isOk()) {
+          assertEquals(
+            result.value,
+            "ユーザーとして送ったメッセージはこれで2通目です。",
+          );
+        }
+
+        assertEquals(
+          progressMessages.some((message) =>
+            message.includes("ユーザーとして送ったメッセージはこれで2通目です。")
+          ),
+          true,
+        );
+        assertEquals(state.sessionId, "session-exec-json");
+      } finally {
+        await Deno.remove(repoPath, { recursive: true });
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add Codex exec JSON event parsing helpers to extract agent messages, tool output, session IDs, and token usage safely
- update the worker stream handling to recognize exec events, preserve history, and surface final messages instead of falling back to a generic error
- cover the exec JSON agent message flow with a regression test to ensure responses propagate and sessions persist

## Testing
- `deno test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6903497d8a288330a853fc99a3673abe